### PR TITLE
[feat] 게시글 작성 페이지 구현 (이미지 첨부 제외)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ const port = process.env.PORT;
 app.use(cookieParser());
 app.use(authGuard);
 app.use(express.static(path.join(import.meta.dirname, 'public')));
+app.use('/write', express.static(path.join(import.meta.dirname, 'public', 'post-write')));
 
 app.get('/index', (req, res) => {
     res.sendFile(path.join(import.meta.dirname, 'public', 'index', 'index.html'));
@@ -17,6 +18,10 @@ app.get('/index', (req, res) => {
 
 app.get('/login', (req, res) => {
     res.sendFile(path.join(import.meta.dirname, 'public', 'login', 'login.html'));
+});
+
+app.get('/write', (req, res) => {
+    res.sendFile(path.join(import.meta.dirname, 'public', 'post-write', 'post-write.html'));
 });
 
 app.listen(port, () => {

--- a/src/public/api/posts.js
+++ b/src/public/api/posts.js
@@ -19,6 +19,22 @@ export const requestPosts = async (params = {}) => {
     }
 };
 
+export const requestWritePost = async (requestBody = {}) => {
+    try {
+        const res = await fetch(`${API_SERVER_URI}/posts`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(requestBody),
+        });
+        const json = await res.json();
+        return json;
+    } catch (error) {
+        console.error(error);
+        return { success: false, data: '문제가 발생했습니다' };
+    }
+};
+
 /**
  * lastPostId와 limit 필드로만 쿼리 스트링을 구성합니다
  * 단, lastPostId 혹은 limit이 숫자나 문자열 숫자일 때만 유효한 값으로 인정합니다

--- a/src/public/component/common/form/form.css
+++ b/src/public/component/common/form/form.css
@@ -25,3 +25,9 @@ form div {
 .form-submit-btn {
     background-color: #c5b0cd;
 }
+
+.inactivated {
+    background-color: #c5b0cd70;
+    color: #c5b0cd;
+    cursor: not-allowed;
+}

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -23,3 +23,22 @@ export const validatePasswordPattern = (password) => {
     const regex = /^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9])(?=.*?[~.!@#$%^&*()_\-+=\[\]{}|\\;:'",?/]).{8,20}$/;
     return regex.test(password);
 };
+
+export const validatePostTitlePattern = (title) => {
+    return {
+        isValidated: title.length > 0 && title.length < 27,
+        message:
+            title.length == 0
+                ? '제목을 입력해주세요'
+                : title.length > 26
+                  ? '제목은 최대 26글자까지 입력할 수 있습니다'
+                  : '',
+    };
+};
+
+export const validatePostContentPattern = (content) => {
+    return {
+        isValidated: content.length > 0,
+        message: content.length == 0 ? '내용을 입력해주세요' : '',
+    };
+};

--- a/src/public/component/common/header/header.css
+++ b/src/public/component/common/header/header.css
@@ -10,6 +10,14 @@
     font-size: 1.5em;
 }
 
+.backward-image {
+    cursor: pointer;
+}
+
+.profile-image {
+    cursor: pointer;
+}
+
 .profile-list {
     list-style: none;
     position: absolute;

--- a/src/public/component/common/header/header.js
+++ b/src/public/component/common/header/header.js
@@ -28,6 +28,10 @@ const profileImageClickListHandler = () => {
     document.querySelector('.profile-list').classList.toggle('hide');
 };
 
+const backwardImageClickHandler = () => {
+    history.back();
+};
+
 document.addEventListener('DOMContentLoaded', () => {
     const backwardList = ['/read', '/write', '/update'];
     const isLogin = document.cookie.includes('isLogin=true');
@@ -38,5 +42,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // 로그인한 상태라면 노출된 profile 이미지 클릭 이벤트 등록
     if (isLogin) {
         document.querySelector('.profile-image').addEventListener('click', profileImageClickListHandler);
+    }
+
+    // 뒤로 가기 버튼이 노출된 상태라면 이전 페이지로 이동하는 클릭 이벤트 등록
+    if (existsBackward) {
+        document.querySelector('.backward-image').addEventListener('click', backwardImageClickHandler);
     }
 });

--- a/src/public/component/post/post.js
+++ b/src/public/component/post/post.js
@@ -1,0 +1,43 @@
+/* HTML */
+const generatePostFormHtml = (post) => {
+    return `
+        <div class="title">게시글 ${post?.id ? '수정' : '작성'}</div>
+        <form class="form">
+            <div>
+                <label for="form-title-input" class="form-label">제목*</label>
+                <input
+                    name="제목"
+                    type="input"
+                    class="form-input required"
+                    id="form-title-input"
+                    placeholder="제목을 입력해주세요. (최대 26글자)"
+                    data-validated="false"
+                    value="${post?.title ?? ''}"
+                />
+                <div class="form-helper-text form-helper-title">제목을 작성해주세요</div>
+            </div>
+            <div>
+                <label for="form-content-input" class="form-label">내용*</label>
+                <textarea
+                    name="내용"
+                    class="form-input required"
+                    id="form-content-input"
+                    placeholder="내용을 입력해주세요."
+                    data-validated="false"
+                    rows="25"
+                >${post?.content ?? ''}</textarea>
+                <div class="form-helper-text form-helper-content">내용을 작성해주세요</div>
+            </div>
+            <div>
+                <label for="form-file-input" class="form-label">이미지</label>
+                <input name="이미지" type="file" class="" id="form-file-input" />
+            </div>
+            <div>
+                <button class="btn form-submit-btn inactivated" type="button">완료</button>
+            </div>
+        </form>`;
+};
+
+export const paintPostForm = (post = {}) => {
+    document.querySelector('section').insertAdjacentHTML('beforeend', generatePostFormHtml(post));
+};

--- a/src/public/component/post/posts.js
+++ b/src/public/component/post/posts.js
@@ -1,0 +1,32 @@
+import { formatDate, formatCount } from '../../utils/formatHelper.js';
+
+const generatePostContainerHtml = (post) => {
+    return `
+        <div class="post-container" data-postId="${post.id}">
+            <div class="post">
+                <div class="post-title">${post.title}</div>
+                <div class="post-info">
+                    <div class="post-stat">
+                        <div>좋아요 <span class="post-like-count">${formatCount(post.likeCount)}</div>
+                        <div>댓글 <span class="post-comment-count">${formatCount(post.commentCount)}</div>
+                        <div>조회수 <span class="post-view-count">${formatCount(post.viewCount)}</div>
+                    </div>
+                    <div class="post-created-at">${formatDate(post.createdAt)}</div>
+                </div>
+            </div>
+            <div class="custom-hr"></div>
+            <div class="post-member">
+                <div class="post-member-image">${post.member.image?.id ?? '👤'}</div>
+                <div class="post-member-name">${post.member.nickname}</div>
+            </div>
+        </div>`;
+    // TODO: post.member.image.id 있으면 프로필 이미지 가져오기
+};
+
+const generatePostsContainerHtml = (posts) => {
+    return posts.map((post) => generatePostContainerHtml(post)).join('');
+};
+
+export const paintPostContainer = (posts) => {
+    document.querySelector('.posts-container').insertAdjacentHTML('beforeend', generatePostsContainerHtml(posts));
+};

--- a/src/public/index/index.html
+++ b/src/public/index/index.html
@@ -19,7 +19,7 @@
                     <div>아무 말 대잔치 게시판입니다.</div>
                 </div>
                 <div class="post-write-btn">
-                    <button type="button" class="btn purple"><a href="">게시글 작성</a></button>
+                    <button type="button" class="btn purple"><a href="/write">게시글 작성</a></button>
                 </div>
                 <div class="posts-container"></div>
             </section>

--- a/src/public/index/index.js
+++ b/src/public/index/index.js
@@ -1,44 +1,5 @@
+import { paintPostContainer } from '../component/post/posts.js';
 import { requestPosts } from '../api/posts.js';
-import { formatDate, formatCount } from '../utils/formatHelper.js';
-
-const generatePostContainerHtml = (post) => {
-    return `
-        <div class="post-container" data-postId="${post.id}">
-            <div class="post">
-                <div class="post-title">${post.title}</div>
-                <div class="post-info">
-                    <div class="post-stat">
-                        <div>좋아요 <span class="post-like-count">${formatCount(post.likeCount)}</div>
-                        <div>댓글 <span class="post-comment-count">${formatCount(post.commentCount)}</div>
-                        <div>조회수 <span class="post-view-count">${formatCount(post.viewCount)}</div>
-                    </div>
-                    <div class="post-created-at">${formatDate(post.createdAt)}</div>
-                </div>
-            </div>
-            <div class="custom-hr"></div>
-            <div class="post-member">
-                <div class="post-member-image">${post.member.image?.id ?? '👤'}</div>
-                <div class="post-member-name">${post.member.nickname}</div>
-            </div>
-        </div>`;
-    // TODO: post.member.image.id 있으면 프로필 이미지 가져오기
-};
-
-const generatePostsContainerHtml = (posts) => {
-    return posts.map((post) => generatePostContainerHtml(post)).join('');
-};
-
-const paintPostContainer = async () => {
-    const postsContainer = document.querySelector('.posts-container');
-    const res = await requestPosts();
-
-    if (!res.success) {
-        postsContainer.textContent = res.data;
-        return;
-    }
-
-    postsContainer.insertAdjacentHTML('beforeend', generatePostsContainerHtml(res.data.posts));
-};
 
 const postsContainerClickHandler = (target) => {
     const postContainer = target.closest('.post-container');
@@ -50,7 +11,14 @@ const postsContainerClickHandler = (target) => {
 };
 
 document.addEventListener('DOMContentLoaded', async () => {
-    paintPostContainer();
+    const res = await requestPosts();
+
+    if (!res.success) {
+        document.querySelector('.posts-container').textContent = res.data;
+        return;
+    }
+
+    paintPostContainer(res.data.posts);
 
     document.querySelector('.posts-container').addEventListener('click', ({ target }) => {
         postsContainerClickHandler(target);

--- a/src/public/post-write/post-write.html
+++ b/src/public/post-write/post-write.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>아무 말 대잔치</title>
+
+        <link rel="stylesheet" href="../style.css" />
+        <link rel="stylesheet" href="../component/common/header/header.css" />
+        <link rel="stylesheet" href="../component/common/form/form.css" />
+    </head>
+    <body>
+        <header></header>
+
+        <main>
+            <section></section>
+        </main>
+
+        <script type="module" src="../component/common/header/header.js"></script>
+        <script type="module" src="./post-write.js"></script>
+    </body>
+</html>

--- a/src/public/post-write/post-write.js
+++ b/src/public/post-write/post-write.js
@@ -15,6 +15,18 @@ const validationRules = {
     },
 };
 
+const ChangeFormSubmitBtnStatus = () => {
+    const formTitleInput = document.querySelector('#form-title-input');
+    const formContentInput = document.querySelector('#form-content-input');
+    const formSubmitBtn = document.querySelector('.form-submit-btn');
+
+    if (formTitleInput.dataset.validated === 'true' && formContentInput.dataset.validated === 'true') {
+        formSubmitBtn.classList.remove('inactivated');
+    } else {
+        formSubmitBtn.classList.add('inactivated');
+    }
+};
+
 const formInputKeyUpHandler = (name, target) => {
     const title = target.value;
     const helper = target.nextElementSibling;
@@ -28,6 +40,8 @@ const formInputKeyUpHandler = (name, target) => {
 
     target.dataset.validated = result.isValidated;
     helper.textContent = result.message;
+
+    ChangeFormSubmitBtnStatus();
 };
 
 const formSubmitBtnClickHandler = async () => {
@@ -69,18 +83,6 @@ document.addEventListener('DOMContentLoaded', () => {
     formContentInput.addEventListener('keyup', ({ target }) => {
         formInputKeyUpHandler('content', target);
     });
-
-    const observer = new MutationObserver((mutationList, observer) => {
-        if (formTitleInput.dataset.validated === 'true' && formContentInput.dataset.validated === 'true') {
-            formSubmitBtn.classList.remove('inactivated');
-        } else {
-            formSubmitBtn.classList.add('inactivated');
-        }
-    });
-
-    document
-        .querySelectorAll('[data-validated]')
-        .forEach((e) => observer.observe(e, { attributes: true, attributeFilter: ['data-validated'] }));
 
     formSubmitBtn.addEventListener('click', formSubmitBtnClickHandler);
 });

--- a/src/public/post-write/post-write.js
+++ b/src/public/post-write/post-write.js
@@ -1,0 +1,86 @@
+import {
+    validateRequiredInput,
+    validatePostTitlePattern,
+    validatePostContentPattern,
+} from '../component/common/form/form.js';
+import { requestWritePost } from '../api/posts.js';
+import { paintPostForm } from '../component/post/post.js';
+
+const validationRules = {
+    title: {
+        validateFunc: validatePostTitlePattern,
+    },
+    content: {
+        validateFunc: validatePostContentPattern,
+    },
+};
+
+const formInputKeyUpHandler = (name, target) => {
+    const title = target.value;
+    const helper = target.nextElementSibling;
+
+    const previousValidated = target.dataset.validated === 'true';
+    const result = validationRules[name].validateFunc(title);
+
+    if (previousValidated == result.isValidated) {
+        return;
+    }
+
+    target.dataset.validated = result.isValidated;
+    helper.textContent = result.message;
+};
+
+const formSubmitBtnClickHandler = async () => {
+    const form = document.querySelector('.form');
+
+    if (!validateRequiredInput(form)) {
+        return;
+    }
+
+    const title = form.querySelector('#form-title-input');
+    const content = form.querySelector('#form-content-input');
+
+    if (title.dataset.validated !== 'true' || content.dataset.validated !== 'true') {
+        return;
+    }
+
+    const requestBody = { title: title.value, content: content.value };
+    const res = await requestWritePost(requestBody);
+
+    if (!res.success) {
+        content.nextElementSibling.textContent = '??????';
+        return;
+    }
+
+    location.href = `/posts/${res.data.post.id}`;
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    paintPostForm();
+
+    const formTitleInput = document.querySelector('#form-title-input');
+    const formContentInput = document.querySelector('#form-content-input');
+    const formSubmitBtn = document.querySelector('.form-submit-btn');
+
+    formTitleInput.addEventListener('keyup', ({ target }) => {
+        formInputKeyUpHandler('title', target);
+    });
+
+    formContentInput.addEventListener('keyup', ({ target }) => {
+        formInputKeyUpHandler('content', target);
+    });
+
+    const observer = new MutationObserver((mutationList, observer) => {
+        if (formTitleInput.dataset.validated === 'true' && formContentInput.dataset.validated === 'true') {
+            formSubmitBtn.classList.remove('inactivated');
+        } else {
+            formSubmitBtn.classList.add('inactivated');
+        }
+    });
+
+    document
+        .querySelectorAll('[data-validated]')
+        .forEach((e) => observer.observe(e, { attributes: true, attributeFilter: ['data-validated'] }));
+
+    formSubmitBtn.addEventListener('click', formSubmitBtnClickHandler);
+});


### PR DESCRIPTION
## 작업 내용

- 게시글 제목과 내용에 대한 헬퍼 텍스트 기능
    - 각 input 태그에 keyUp 이벤트 등록 → 입력할 때마다 검증 함수 실행
        - 입력 값 길이가 0이면 '제목/내용을 입력해주세요' 문구 출력
        - 제목의 경우 입력 값이 26글자를 넘어서면 '제목은 최대 26글자까지 입력할 수 있습니다' 문구 출력

- 게시글 제목과 내용 모두 유효한 범위 작성 시 완료 버튼 활성화
    - `.inactivated` 클래스 있으면 비활성화, 없으면 활성화 상태
    - 제목이나 내용의 유효 상태 범위가 변경될 때마다 버튼을 비활성화/활성화 처리

- 기존 `index.js`에서 post-container 동적 HTML 생성 부분을 `component/post/posts.js`로 옮김

## 고민 내용

### MutationObserver 필요성?
- 기존 버튼 활성화/비활성화 구현 방식
    - 제목과 내용 input 값에 따라 완료 버튼 활성화/비활성화 상태가 변경됨
    - 제목과 내용의 keyUp 이벤트 핸들러에선 유효 값이면 data-validated=true, 아니면 data-validated=false로 변경함
    - MutationObserver는 제목과 내용의 input 태그 중 data-validated 속성이 변경될 때를 감지해 버튼 활성화 여부를 결정하도록 했음
- 그러나 버튼 활성 여부는 결국 제목과 내용의 keyUp 이벤트 핸들러에 의해 결정됨
    - 즉, keyUp 핸들러 내부에서 data-validated 값이 변경될 때마다 버튼 활성화 여부 결정 함수를 호출하면 MutationObserver와 동일한 기능 수행 가능
- MutationObserver 제거 후 keyUp 핸들러 내부에서 버튼 활성화 여부 결정 함수 호출하도록 수정
    - 이벤트 루프를 타는 MutationObserver보다 빠르게(= 즉시) 실행되고 오버헤드가 적음

## 화면 캡처
- 제목과 내용 모두 입력 안 한 경우
    <img width="443" height="634" alt="image" src="https://github.com/user-attachments/assets/c9d9ceac-9d09-4282-902b-7282ed380e28" />

- 제목 26글자 넘어가는 경우
    <img width="1032" height="1085" alt="image" src="https://github.com/user-attachments/assets/35863180-6c2e-4215-92c7-c40304b2f070" />
- 제목과 내용을 모두 유효하게 작성한 경우 완료 버튼 활성화
    <img width="1037" height="1102" alt="image" src="https://github.com/user-attachments/assets/5c73bd5c-f9e6-4b88-9b28-ec4f5b3beea5" />
