### PR TITLE
[feat] 게시글 상세 조회 페이지 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ app.use(cookieParser());
 app.use(authGuard);
 app.use(express.static(path.join(import.meta.dirname, 'public')));
 app.use('/write', express.static(path.join(import.meta.dirname, 'public', 'post-write')));
+app.use('/read', express.static(path.join(import.meta.dirname, 'public', 'post-read')));
 
 app.get('/index', (req, res) => {
     res.sendFile(path.join(import.meta.dirname, 'public', 'index', 'index.html'));
@@ -22,6 +23,10 @@ app.get('/login', (req, res) => {
 
 app.get('/write', (req, res) => {
     res.sendFile(path.join(import.meta.dirname, 'public', 'post-write', 'post-write.html'));
+});
+
+app.get('/read/:postId', (req, res) => {
+    res.sendFile(path.join(import.meta.dirname, 'public', 'post-read', 'post-read.html'));
 });
 
 app.listen(port, () => {

--- a/src/public/api/comments.js
+++ b/src/public/api/comments.js
@@ -1,8 +1,12 @@
 import { API_SERVER_URI } from '../utils/constants.js';
 
-export const requestComments = async (postId) => {
+/**
+ * 매개변수 params = { lastCommentId: number, limit: number }
+ * 그 외 다른 필드가 존재해도 검증을 통해 필요한 필드만 서버에 전송됩니다
+ */
+export const requestComments = async (postId, params = {}) => {
     try {
-        const res = await fetch(`${API_SERVER_URI}/posts/${postId}/comments`, {
+        const res = await fetch(`${API_SERVER_URI}/posts/${postId}/comments?${createQueryString(params)}`, {
             method: 'GET',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
@@ -13,4 +17,22 @@ export const requestComments = async (postId) => {
         console.error(error);
         return { success: false, data: '문제가 발생했습니다' };
     }
+};
+
+/**
+ * lastCommentId와 limit 필드로만 쿼리 스트링을 구성합니다
+ * 단, lastCommentId 혹은 limit이 숫자나 문자열 숫자일 때만 유효한 값으로 인정합니다
+ */
+const createQueryString = (params) => {
+    const validatedParams = {};
+
+    if (!!params?.lastCommentId && !isNaN(params.lastCommentId)) {
+        validatedParams.lastCommentId = params.lastCommentId;
+    }
+
+    if (!!params?.limit && !isNaN(params.limit)) {
+        validatedParams.limit = params.limit;
+    }
+
+    return new URLSearchParams(validatedParams).toString();
 };

--- a/src/public/api/comments.js
+++ b/src/public/api/comments.js
@@ -1,0 +1,16 @@
+import { API_SERVER_URI } from '../utils/constants.js';
+
+export const requestComments = async (postId) => {
+    try {
+        const res = await fetch(`${API_SERVER_URI}/posts/${postId}/comments`, {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+        });
+        const json = await res.json();
+        return json;
+    } catch (error) {
+        console.error(error);
+        return { success: false, data: '문제가 발생했습니다' };
+    }
+};

--- a/src/public/api/post-like.js
+++ b/src/public/api/post-like.js
@@ -1,0 +1,24 @@
+import { API_SERVER_URI } from '../utils/constants.js';
+
+export const requestCreateLike = (postId) => {
+    return requestLike(postId, 'POST');
+};
+
+export const requestCancelLike = async (postId) => {
+    return requestLike(postId, 'DELETE');
+};
+
+const requestLike = async (postId, method) => {
+    try {
+        const res = await fetch(`${API_SERVER_URI}/posts/${postId}/likes`, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+        });
+        const json = await res.json();
+        return json;
+    } catch (error) {
+        console.error(error);
+        return { success: false, data: '문제가 발생했습니다' };
+    }
+};

--- a/src/public/api/posts.js
+++ b/src/public/api/posts.js
@@ -35,6 +35,21 @@ export const requestWritePost = async (requestBody = {}) => {
     }
 };
 
+export const requestReadPost = async (postId) => {
+    try {
+        const res = await fetch(`${API_SERVER_URI}/posts/${postId}`, {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+        });
+        const json = await res.json();
+        return json;
+    } catch (error) {
+        console.error(error);
+        return { success: false, data: '문제가 발생했습니다' };
+    }
+};
+
 /**
  * lastPostId와 limit 필드로만 쿼리 스트링을 구성합니다
  * 단, lastPostId 혹은 limit이 숫자나 문자열 숫자일 때만 유효한 값으로 인정합니다

--- a/src/public/api/posts.js
+++ b/src/public/api/posts.js
@@ -50,6 +50,22 @@ export const requestReadPost = async (postId) => {
     }
 };
 
+export const requestDeletePost = async (postId) => {
+    try {
+        const res = await fetch(`${API_SERVER_URI}/posts/${postId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ postDeleted: true, imageDeleted: false }),
+        });
+        const json = await res.json();
+        return json;
+    } catch (error) {
+        console.error(error);
+        return { success: false, data: '문제가 발생했습니다' };
+    }
+};
+
 /**
  * lastPostId와 limit 필드로만 쿼리 스트링을 구성합니다
  * 단, lastPostId 혹은 limit이 숫자나 문자열 숫자일 때만 유효한 값으로 인정합니다

--- a/src/public/component/comments/comment.css
+++ b/src/public/component/comments/comment.css
@@ -1,0 +1,19 @@
+.comments-container {
+    margin-top: 0.5em;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+}
+
+.comment-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5em;
+}
+
+.comment-info-left {
+    display: inherit;
+    align-items: center;
+    gap: 1em;
+}

--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -1,0 +1,33 @@
+import { formatDate } from '../../utils/formatHelper.js';
+import { generateWriterInfoHtml } from '../common/member/member.js';
+
+const generateCommentContainerHTML = (comment) => {
+    // TODO: 회원 이미지 가져오기
+    return `
+        <div class="comment-container">
+            <div class="comment-info">
+                <div class="comment-info-left">
+                    ${generateWriterInfoHtml(comment.member)}
+                    <div class="comment-created-at">${formatDate(comment.createdAt)}</div>
+                </div>
+                <div>
+                    <button class="btn small-btn" data-id=${comment.id}>수정</button>
+                    <button class="btn small-btn delete-btn" data-domain="댓글" data-id="${comment.id}">삭제</button>
+                </div>
+            </div>
+            <div class="comment-content">${comment.content}</div>
+        </div>`;
+};
+const generateCommentsContainerHTML = (comments) => {
+    const commentContainer = comments.map((comment) => generateCommentContainerHTML(comment)).join('');
+    return `
+        <div class="comments-container">
+            ${commentContainer}
+        </div>`;
+};
+
+export const paintCommentsContainer = (comments) => {
+    document
+        .querySelector('.comments-container')
+        .insertAdjacentHTML('beforeend', generateCommentsContainerHTML(comments));
+};

--- a/src/public/component/common/member/member.js
+++ b/src/public/component/common/member/member.js
@@ -1,7 +1,7 @@
 export const generateWriterInfoHtml = (member) => {
     // TODO: 회원 이미지 가져오기
     return `
-        <div class="writer-info" style="display:flex; align-items:center; gap 0.5em;">
+        <div class="writer-info" style="display:flex; align-items:center; gap: 0.5em;">
             <div class="writer-member-image">👤</div>
             <div class="writer-member-nickname">${member.nickname}</div>
         </div>`;

--- a/src/public/component/common/member/member.js
+++ b/src/public/component/common/member/member.js
@@ -1,0 +1,8 @@
+export const generateWriterInfoHtml = (member) => {
+    // TODO: 회원 이미지 가져오기
+    return `
+        <div class="writer-info" style="display:flex; align-items:center; gap 0.5em;">
+            <div class="writer-member-image">👤</div>
+            <div class="writer-member-nickname">${member.nickname}</div>
+        </div>`;
+};

--- a/src/public/component/post/post.js
+++ b/src/public/component/post/post.js
@@ -1,4 +1,16 @@
+import { formatCount, formatDate } from '../../utils/formatHelper.js';
+import { generateWriterInfoHtml } from '../common/member/member.js';
+
+export const paintPostForm = (post = {}) => {
+    document.querySelector('section').insertAdjacentHTML('beforeend', generatePostFormHtml(post));
+};
+
+export const paintPostReadContainer = (post) => {
+    document.querySelector('section').insertAdjacentHTML('beforeend', generatePostReadContainerHtml(post));
+};
+
 /* HTML */
+// 게시글 작성/수정 HTML
 const generatePostFormHtml = (post) => {
     return `
         <div class="title">게시글 ${post?.id ? '수정' : '작성'}</div>
@@ -38,6 +50,39 @@ const generatePostFormHtml = (post) => {
         </form>`;
 };
 
-export const paintPostForm = (post = {}) => {
-    document.querySelector('section').insertAdjacentHTML('beforeend', generatePostFormHtml(post));
+// 게시글 상세조회 HTML
+const generatePostReadContainerHtml = (post) => {
+    // TODO: 게시글 이미지 가져오기
+
+    return `
+        <div class="post-read-container">
+            <div class="post-title">${post.title}</div>
+            <div class="post-info">
+                <div class="post-info-left">
+                    ${generateWriterInfoHtml(post.member)}
+                    <div class="post-created-at">${formatDate(post.createdAt)}</div>
+                </div>
+                <div>
+                    <button class="btn small-btn"><a href="/update/${post.id}">수정</a></button>
+                    <button class="btn small-btn post-delete-btn" data-domain='게시글' data-id="${post.id}">삭제</button>
+                </div>
+            </div>
+            <div class="custom-hr"></div>
+            <div class="post-image"></div>
+            <div class="post-content">${post.content}</div>
+            <div class="post-stat-container">
+                <div class="post-stat">
+                    <div class="post-like-count">${formatCount(post.likeCount)}</div>
+                    <div>좋아요수</div>
+                </div>
+                <div class="post-stat">
+                    <div class="post-view-count">${formatCount(post.viewCount)}</div>
+                    <div>조회수</div>
+                </div>
+                <div class="post-stat">
+                    <div class="post-comment-count">${formatCount(post.commentCount)}</div>
+                    <div>댓글</div>
+                </div>
+            </div>
+        </div>`;
 };

--- a/src/public/component/post/post.js
+++ b/src/public/component/post/post.js
@@ -71,7 +71,7 @@ const generatePostReadContainerHtml = (post) => {
             <div class="post-image"></div>
             <div class="post-content">${post.content}</div>
             <div class="post-stat-container">
-                <div class="post-stat">
+                <div class="post-stat post-like-count-container" data-isLiked="${post.liked}">
                     <div class="post-like-count">${formatCount(post.likeCount)}</div>
                     <div>좋아요수</div>
                 </div>

--- a/src/public/component/post/post.js
+++ b/src/public/component/post/post.js
@@ -6,7 +6,7 @@ export const paintPostForm = (post = {}) => {
 };
 
 export const paintPostReadContainer = (post) => {
-    document.querySelector('section').insertAdjacentHTML('beforeend', generatePostReadContainerHtml(post));
+    document.querySelector('.post-container').insertAdjacentHTML('beforeend', generatePostReadContainerHtml(post));
 };
 
 /* HTML */
@@ -55,34 +55,32 @@ const generatePostReadContainerHtml = (post) => {
     // TODO: 게시글 이미지 가져오기
 
     return `
-        <div class="post-read-container">
-            <div class="post-title">${post.title}</div>
-            <div class="post-info">
-                <div class="post-info-left">
-                    ${generateWriterInfoHtml(post.member)}
-                    <div class="post-created-at">${formatDate(post.createdAt)}</div>
-                </div>
-                <div>
-                    <button class="btn small-btn"><a href="/update/${post.id}">수정</a></button>
-                    <button class="btn small-btn post-delete-btn" data-domain='게시글' data-id="${post.id}">삭제</button>
-                </div>
+        <div class="post-title">${post.title}</div>
+        <div class="post-info">
+            <div class="post-info-left">
+                ${generateWriterInfoHtml(post.member)}
+                <div class="post-created-at">${formatDate(post.createdAt)}</div>
             </div>
-            <div class="custom-hr"></div>
-            <div class="post-image"></div>
-            <div class="post-content">${post.content}</div>
-            <div class="post-stat-container">
-                <div class="post-stat post-like-count-container" data-isLiked="${post.liked}">
-                    <div class="post-like-count">${formatCount(post.likeCount)}</div>
-                    <div>좋아요수</div>
-                </div>
-                <div class="post-stat">
-                    <div class="post-view-count">${formatCount(post.viewCount)}</div>
-                    <div>조회수</div>
-                </div>
-                <div class="post-stat">
-                    <div class="post-comment-count">${formatCount(post.commentCount)}</div>
-                    <div>댓글</div>
-                </div>
+            <div>
+                <button class="btn small-btn"><a href="/update/${post.id}">수정</a></button>
+                <button class="btn small-btn post-delete-btn" data-domain='게시글' data-id="${post.id}">삭제</button>
+            </div>
+        </div>
+        <div class="custom-hr"></div>
+        <div class="post-image"></div>
+        <div class="post-content">${post.content}</div>
+        <div class="post-stat-container">
+            <div class="post-stat post-like-count-container" data-isLiked="${post.liked}">
+                <div class="post-like-count">${formatCount(post.likeCount)}</div>
+                <div>좋아요수</div>
+            </div>
+            <div class="post-stat">
+                <div class="post-view-count">${formatCount(post.viewCount)}</div>
+                <div>조회수</div>
+            </div>
+            <div class="post-stat">
+                <div class="post-comment-count">${formatCount(post.commentCount)}</div>
+                <div>댓글</div>
             </div>
         </div>`;
 };

--- a/src/public/component/post/posts.js
+++ b/src/public/component/post/posts.js
@@ -1,4 +1,5 @@
 import { formatDate, formatCount } from '../../utils/formatHelper.js';
+import { generateWriterInfoHtml } from '../common/member/member.js';
 
 const generatePostContainerHtml = (post) => {
     return `
@@ -15,10 +16,7 @@ const generatePostContainerHtml = (post) => {
                 </div>
             </div>
             <div class="custom-hr"></div>
-            <div class="post-member">
-                <div class="post-member-image">${post.member.image?.id ?? '👤'}</div>
-                <div class="post-member-name">${post.member.nickname}</div>
-            </div>
+            ${generateWriterInfoHtml(post.member)}
         </div>`;
     // TODO: post.member.image.id 있으면 프로필 이미지 가져오기
 };

--- a/src/public/index/index.css
+++ b/src/public/index/index.css
@@ -40,8 +40,3 @@
     display: flex;
     gap: 0.5em;
 }
-
-.post-member {
-    display: flex;
-    gap: 0.5em;
-}

--- a/src/public/index/index.js
+++ b/src/public/index/index.js
@@ -7,7 +7,7 @@ const postsContainerClickHandler = (target) => {
     if (!postContainer) return;
 
     const postId = postContainer.dataset.postid;
-    location.href = `/posts/${postId}`;
+    location.href = `/read/${postId}`;
 };
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/src/public/post-read/post-read.css
+++ b/src/public/post-read/post-read.css
@@ -1,4 +1,4 @@
-.post-read-container {
+.post-container {
     display: flex;
     flex-direction: column;
     gap: 1em;

--- a/src/public/post-read/post-read.css
+++ b/src/public/post-read/post-read.css
@@ -1,0 +1,44 @@
+.post-read-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+    margin-bottom: 1em;
+}
+
+.post-title {
+    font-size: 2em;
+}
+
+.post-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.post-info-left {
+    display: inherit;
+    align-items: center;
+    gap: 1em;
+}
+
+.post-stat-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1em;
+}
+
+.post-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    border-radius: 4px;
+    background-color: #bab5bc;
+    width: 6em;
+    height: 4em;
+    padding: 0.5em;
+    font-weight: bold;
+    cursor: pointer;
+}

--- a/src/public/post-read/post-read.css
+++ b/src/public/post-read/post-read.css
@@ -40,5 +40,8 @@
     height: 4em;
     padding: 0.5em;
     font-weight: bold;
+}
+
+.post-like-count-container {
     cursor: pointer;
 }

--- a/src/public/post-read/post-read.html
+++ b/src/public/post-read/post-read.html
@@ -14,7 +14,11 @@
         <header></header>
 
         <main>
-            <section></section>
+            <section>
+                <div class="post-container"></div>
+                <div class="custom-hr"></div>
+                <div class="comments-container"></div>
+            </section>
         </main>
 
         <script type="module" src="../component/common/header/header.js"></script>

--- a/src/public/post-read/post-read.html
+++ b/src/public/post-read/post-read.html
@@ -7,6 +7,8 @@
 
         <link rel="stylesheet" href="../style.css" />
         <link rel="stylesheet" href="../component/common/header/header.css" />
+        <link rel="stylesheet" href="../component/common/form/form.css" />
+        <link rel="stylesheet" href="./post-read.css" />
     </head>
     <body>
         <header></header>
@@ -16,5 +18,6 @@
         </main>
 
         <script type="module" src="../component/common/header/header.js"></script>
+        <script type="module" src="./post-read.js"></script>
     </body>
 </html>

--- a/src/public/post-read/post-read.html
+++ b/src/public/post-read/post-read.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>아무 말 대잔치</title>
+
+        <link rel="stylesheet" href="../style.css" />
+        <link rel="stylesheet" href="../component/common/header/header.css" />
+    </head>
+    <body>
+        <header></header>
+
+        <main>
+            <section></section>
+        </main>
+
+        <script type="module" src="../component/common/header/header.js"></script>
+    </body>
+</html>

--- a/src/public/post-read/post-read.html
+++ b/src/public/post-read/post-read.html
@@ -8,6 +8,7 @@
         <link rel="stylesheet" href="../style.css" />
         <link rel="stylesheet" href="../component/common/header/header.css" />
         <link rel="stylesheet" href="../component/common/form/form.css" />
+        <link rel="stylesheet" href="../component/comments/comment.css" />
         <link rel="stylesheet" href="./post-read.css" />
     </head>
     <body>

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -1,3 +1,4 @@
+import { requestCancelLike, requestCreateLike } from '../api/post-like.js';
 import { requestReadPost, requestDeletePost } from '../api/posts.js';
 import { paintPostReadContainer } from '../component/post/post.js';
 
@@ -16,6 +17,22 @@ const deleteBtnClickHandler = async (target) => {
 
     location.href = '/index';
 };
+
+const postLikeCountContainerClickHandler = async (target, postId) => {
+    const previoustIsLiked = target.dataset.isliked === 'true';
+    const request = previoustIsLiked === true ? requestCancelLike : requestCreateLike;
+
+    const res = await request(postId);
+
+    if (!res.success) {
+        alert(res.data);
+        return;
+    }
+
+    target.dataset.isliked = !previoustIsLiked;
+    target.firstElementChild.textContent = res.data.likeCount;
+};
+
 document.addEventListener('DOMContentLoaded', async () => {
     const postId = Number(window.location.pathname.split('/').at(2));
     const res = await requestReadPost(postId);
@@ -29,5 +46,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     document.querySelector('.post-delete-btn').addEventListener('click', ({ target }) => {
         deleteBtnClickHandler(target);
+    });
+
+    document.querySelector('.post-like-count-container').addEventListener('click', ({ currentTarget }) => {
+        postLikeCountContainerClickHandler(currentTarget, postId);
     });
 });

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -1,0 +1,33 @@
+import { requestReadPost, requestDeletePost } from '../api/posts.js';
+import { paintPostReadContainer } from '../component/post/post.js';
+
+const deleteBtnClickHandler = async (target) => {
+    // TODO: 모달창 띄우기
+    if (!confirm(`${target.dataset.domain} 삭제하시겠습니까? 삭제한 내용은 복구할 수 없습니다`)) {
+        return;
+    }
+
+    const res = await requestDeletePost(target.dataset.id);
+
+    if (!res.success) {
+        alert(res.data);
+        return;
+    }
+
+    location.href = '/index';
+};
+document.addEventListener('DOMContentLoaded', async () => {
+    const postId = Number(window.location.pathname.split('/').at(2));
+    const res = await requestReadPost(postId);
+
+    if (!res.success) {
+        document.querySelector('section').textContent = res.data;
+        return;
+    }
+
+    paintPostReadContainer(res.data.post);
+
+    document.querySelector('.post-delete-btn').addEventListener('click', ({ target }) => {
+        deleteBtnClickHandler(target);
+    });
+});

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -1,5 +1,7 @@
 import { requestCancelLike, requestCreateLike } from '../api/post-like.js';
 import { requestReadPost, requestDeletePost } from '../api/posts.js';
+import { requestComments } from '../api/comments.js';
+import { paintCommentsContainer } from '../component/comments/comments.js';
 import { paintPostReadContainer } from '../component/post/post.js';
 
 const deleteBtnClickHandler = async (target) => {
@@ -35,14 +37,14 @@ const postLikeCountContainerClickHandler = async (target, postId) => {
 
 document.addEventListener('DOMContentLoaded', async () => {
     const postId = Number(window.location.pathname.split('/').at(2));
-    const res = await requestReadPost(postId);
+    const postRes = await requestReadPost(postId);
 
-    if (!res.success) {
-        document.querySelector('section').textContent = res.data;
+    if (!postRes.success) {
+        document.querySelector('section').textContent = postRes.data;
         return;
     }
 
-    paintPostReadContainer(res.data.post);
+    paintPostReadContainer(postRes.data.post);
 
     document.querySelector('.post-delete-btn').addEventListener('click', ({ target }) => {
         deleteBtnClickHandler(target);
@@ -51,4 +53,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelector('.post-like-count-container').addEventListener('click', ({ currentTarget }) => {
         postLikeCountContainerClickHandler(currentTarget, postId);
     });
+
+    /* 댓글 */
+    const commentRes = await requestComments(postId);
+
+    if (!commentRes.success) {
+        document.querySelector('.comments-container').textContent = commentRes.data;
+        return;
+    }
+
+    paintCommentsContainer(commentRes.data.comments);
 });

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -43,6 +43,12 @@ section {
     font-size: 1em;
 }
 
+.small-btn {
+    background-color: #ffffff;
+    border: 1px solid #415e72;
+    font-size: 0.8em;
+}
+
 .purple {
     background-color: #c5b0cd;
 }


### PR DESCRIPTION
## 작업 내용

- 스프링 서버로 fetch 요청 날리는 함수 작성
    - 특정 게시글 조회 요청
    - 특정 게시글 소프트 삭제 요청
    - 특정 게시글의 댓글 목록 조회 요청
    - 좋아요 생성/삭제 요청

- 게시글 및 댓글 작성자 정보 나타내는 HTML 공통 컴포넌트에 추가 및 활용
    - 전체 게시글 조회, 게시글 상세 조회, 댓글 조회 시 공통적으로 사용됨

- 좋아요수 클릭 시 좋아요 생성 또는 취소
    - `data-isliked` 속성을 통해 로그인한 회원이 해당 게시글에 좋아요를 눌렀는지 안 눌렀는지 파악
    - 좋아요수 컨테이너 클릭 시 해당 속성 값을 기반으로 좋아요 생성 또는 취소 요청

<br>
<br>
<br>

## 고민 내용

<br>
<br>
<br>

## 화면 캡처
<img width="945" height="979" alt="image" src="https://github.com/user-attachments/assets/044cf5cc-c63f-4930-9665-a6c8a5108802" />
