### PR TITLE
[feat] 모달 구현

### DIFF
--- a/src/public/api/comments.js
+++ b/src/public/api/comments.js
@@ -19,6 +19,20 @@ export const requestComments = async (postId, params = {}) => {
     }
 };
 
+export const requestDeleteComment = async (postId) => {
+    try {
+        await fetch(`${API_SERVER_URI}/posts/${postId}/comments`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+        });
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false, data: '문제가 발생했습니다' };
+    }
+};
+
 /**
  * lastCommentId와 limit 필드로만 쿼리 스트링을 구성합니다
  * 단, lastCommentId 혹은 limit이 숫자나 문자열 숫자일 때만 유효한 값으로 인정합니다

--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -4,7 +4,7 @@ import { generateWriterInfoHtml } from '../common/member/member.js';
 const generateCommentContainerHtml = (comment) => {
     // TODO: 회원 이미지 가져오기
     return `
-        <div class="comment-container">
+        <div class="comment-container" data-commentid="${comment.id}">
             <div class="comment-info">
                 <div class="comment-info-left">
                     ${generateWriterInfoHtml(comment.member)}
@@ -12,18 +12,14 @@ const generateCommentContainerHtml = (comment) => {
                 </div>
                 <div>
                     <button class="btn small-btn" data-id=${comment.id}>수정</button>
-                    <button class="btn small-btn delete-btn" data-domain="댓글" data-id="${comment.id}">삭제</button>
+                    <button class="btn small-btn delete-btn" data-domain="comment" data-id="${comment.id}">삭제</button>
                 </div>
             </div>
             <div class="comment-content">${comment.content}</div>
         </div>`;
 };
 const generateCommentsContainerHtml = (comments) => {
-    const commentContainer = comments.map((comment) => generateCommentContainerHtml(comment)).join('');
-    return `
-        <div class="comments-container">
-            ${commentContainer}
-        </div>`;
+    return comments.map((comment) => generateCommentContainerHtml(comment)).join('');
 };
 
 export const paintCommentsContainer = (comments) => {

--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -1,7 +1,7 @@
 import { formatDate } from '../../utils/formatHelper.js';
 import { generateWriterInfoHtml } from '../common/member/member.js';
 
-const generateCommentContainerHTML = (comment) => {
+const generateCommentContainerHtml = (comment) => {
     // TODO: 회원 이미지 가져오기
     return `
         <div class="comment-container">
@@ -18,8 +18,8 @@ const generateCommentContainerHTML = (comment) => {
             <div class="comment-content">${comment.content}</div>
         </div>`;
 };
-const generateCommentsContainerHTML = (comments) => {
-    const commentContainer = comments.map((comment) => generateCommentContainerHTML(comment)).join('');
+const generateCommentsContainerHtml = (comments) => {
+    const commentContainer = comments.map((comment) => generateCommentContainerHtml(comment)).join('');
     return `
         <div class="comments-container">
             ${commentContainer}
@@ -29,5 +29,5 @@ const generateCommentsContainerHTML = (comments) => {
 export const paintCommentsContainer = (comments) => {
     document
         .querySelector('.comments-container')
-        .insertAdjacentHTML('beforeend', generateCommentsContainerHTML(comments));
+        .insertAdjacentHTML('beforeend', generateCommentsContainerHtml(comments));
 };

--- a/src/public/component/common/modal/modal.css
+++ b/src/public/component/common/modal/modal.css
@@ -1,0 +1,38 @@
+dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: #ffffff;
+    border-radius: 16px;
+}
+
+dialog::backdrop {
+    background-color: rgba(0, 0, 0, 0.4);
+}
+
+.modal-container {
+    padding: 3em;
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+    text-align: center;
+}
+
+.modal-main-text {
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+.modal-cancel-btn {
+    background-color: #17171b;
+    color: #ffffff;
+    width: 5em;
+    margin: 0.5em;
+}
+
+.modal-confirm-btn {
+    background-color: #c5b0cd;
+    width: 5em;
+    margin: 0.5em;
+}

--- a/src/public/component/common/modal/modal.js
+++ b/src/public/component/common/modal/modal.js
@@ -1,0 +1,7 @@
+export const openDeleteModal = (domain, id) => {
+    const modal = document.querySelector('dialog');
+    modal.dataset.domain = domain; // post, comment
+    modal.dataset.id = id;
+
+    modal.showModal();
+};

--- a/src/public/component/post/post.js
+++ b/src/public/component/post/post.js
@@ -63,7 +63,7 @@ const generatePostReadContainerHtml = (post) => {
             </div>
             <div>
                 <button class="btn small-btn"><a href="/update/${post.id}">수정</a></button>
-                <button class="btn small-btn post-delete-btn" data-domain='게시글' data-id="${post.id}">삭제</button>
+                <button class="btn small-btn delete-btn" data-domain='post' data-id="${post.id}">삭제</button>
             </div>
         </div>
         <div class="custom-hr"></div>

--- a/src/public/index/index.css
+++ b/src/public/index/index.css
@@ -15,7 +15,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5em;
-    border-radius: 16px;
+    border-radius: 8px;
     box-shadow: 5px 5px 14px 0.5px #9c9c9c;
     background-color: #ffffff;
     cursor: pointer;

--- a/src/public/post-read/post-read.html
+++ b/src/public/post-read/post-read.html
@@ -7,6 +7,7 @@
 
         <link rel="stylesheet" href="../style.css" />
         <link rel="stylesheet" href="../component/common/header/header.css" />
+        <link rel="stylesheet" href="../component/common/modal/modal.css" />
         <link rel="stylesheet" href="../component/common/form/form.css" />
         <link rel="stylesheet" href="../component/comments/comment.css" />
         <link rel="stylesheet" href="./post-read.css" />
@@ -20,9 +21,20 @@
                 <div class="custom-hr"></div>
                 <div class="comments-container"></div>
             </section>
+            <dialog data-type="" data-id="">
+                <div class="modal-container">
+                    <div class="modal-main-text">삭제하시겠습니까?</div>
+                    <div class="modal-sub-text">삭제한 내용은 복구할 수 없습니다</div>
+                    <div class="modal-buttons">
+                        <button type="button" class="btn modal-cancel-btn">취소</button>
+                        <button type="button" class="btn modal-confirm-btn">확인</button>
+                    </div>
+                </div>
+            </dialog>
         </main>
 
         <script type="module" src="../component/common/header/header.js"></script>
+        <script type="module" src="../component/common/modal/modal.js"></script>
         <script type="module" src="./post-read.js"></script>
     </body>
 </html>

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -1,16 +1,17 @@
 import { requestCancelLike, requestCreateLike } from '../api/post-like.js';
 import { requestReadPost, requestDeletePost } from '../api/posts.js';
-import { requestComments } from '../api/comments.js';
+import { requestComments, requestDeleteComment } from '../api/comments.js';
 import { paintCommentsContainer } from '../component/comments/comments.js';
 import { paintPostReadContainer } from '../component/post/post.js';
+import { openDeleteModal } from '../component/common/modal/modal.js';
 
-const deleteBtnClickHandler = async (target) => {
-    // TODO: 모달창 띄우기
-    if (!confirm(`${target.dataset.domain} 삭제하시겠습니까? 삭제한 내용은 복구할 수 없습니다`)) {
-        return;
-    }
+const deleteHandlerMap = {
+    post: (id) => deletePostHandler(id),
+    comment: (id) => deleteCommentHandler(id),
+};
 
-    const res = await requestDeletePost(target.dataset.id);
+const deletePostHandler = async (id) => {
+    const res = await requestDeletePost(id);
 
     if (!res.success) {
         alert(res.data);
@@ -18,6 +19,27 @@ const deleteBtnClickHandler = async (target) => {
     }
 
     location.href = '/index';
+};
+
+const deleteCommentHandler = async (id) => {
+    const res = await requestDeleteComment(id);
+
+    if (!res.success) {
+        alert(res.data);
+        return;
+    }
+
+    const deletedElement = document.querySelector(`[data-commentid="${id}"]`);
+    document.querySelector('.comments-container').removeChild(deletedElement);
+    // document.querySelector('.post-comment-count').textContent = res.data.commentCount;
+
+    document.querySelector('dialog').close();
+};
+
+const modalConfirmBtnClickHandler = async (target) => {
+    const dialog = target.closest('dialog');
+    const { domain, id } = dialog.dataset;
+    deleteHandlerMap[domain](id);
 };
 
 const postLikeCountContainerClickHandler = async (target, postId) => {
@@ -36,6 +58,7 @@ const postLikeCountContainerClickHandler = async (target, postId) => {
 };
 
 document.addEventListener('DOMContentLoaded', async () => {
+    /* 게시글 */
     const postId = Number(window.location.pathname.split('/').at(2));
     const postRes = await requestReadPost(postId);
 
@@ -45,10 +68,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     paintPostReadContainer(postRes.data.post);
-
-    document.querySelector('.post-delete-btn').addEventListener('click', ({ target }) => {
-        deleteBtnClickHandler(target);
-    });
 
     document.querySelector('.post-like-count-container').addEventListener('click', ({ currentTarget }) => {
         postLikeCountContainerClickHandler(currentTarget, postId);
@@ -63,4 +82,19 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     paintCommentsContainer(commentRes.data.comments);
+
+    /* 삭제 모달 이벤트 등록 */
+    document.querySelectorAll('.delete-btn').forEach((btn) =>
+        btn.addEventListener('click', () => {
+            openDeleteModal(btn.dataset.domain, btn.dataset.id);
+        })
+    );
+
+    document.querySelector('.modal-cancel-btn').addEventListener('click', () => {
+        document.querySelector('dialog').close();
+    });
+
+    document.querySelector('.modal-confirm-btn').addEventListener('click', ({ target }) => {
+        modalConfirmBtnClickHandler(target);
+    });
 });


### PR DESCRIPTION
## 작업 내용

- 스프링 서버로 댓글 삭제 요청하는 함수 작성
- 삭제 모달 HTML, CSS 작성
- 게시글 상세 조회 시 게시글 삭제 혹은 댓글 삭제 버튼 클릭 시 모달 열리도록 설정
- 모달 내 취소 버튼 클릭 시 모달 닫기
- 모달 내 확인 버튼 클릭 시 게시글/댓글 삭제 요청 함수 실행
    - 어떤 도메인(게시글, 댓글)의 어떤 레코드(id)를 삭제하는지는 dataset 속성 활용
    - 게시글/댓글 삭제 버튼 클릭 시 어떤 도메인의 ID에 대한 모달인지 나타내기 위해 dialog 태그에 `data-domain`, `data-id` 속성에 저장 → 삭제 요청 시 dataset 속성 정보를 기반으로 적절한 삭제 처리 함수 선택 및 삭제하는 레코드 ID 전달

<br>
<br>
<br>

## 고민 내용

### 공통 모듈을 어떻게 활용해야 하지?
- 모달은 게시글 삭제, 댓글 삭제, 회원 탈퇴에서 사용되는 공용 컴포넌트라고 생각해서 `component/common/`에 추가하려고 했음
- 모달 열기, 닫기, 확인 버튼 클릭 시 보내는 요청 등은 각 상황에 따라 달라짐
- addEventListener()로 이벤트를 등록하려고 해도 어떤 버튼을 클릭할지는 modal이 아니라 그 모달을 사용하는 index, login, post-read 같은 페이지의 html에서 알 수 있는데?
    - 그럼 각 페이지의 자바스크립트 파일마다 모달 열기, 닫기 등의 이벤트 리스너를 작성하나?
    - 모달이라는 공통 모듈을 사용하는데, 그 처리 로직이 모달 모듈이 아니라 그걸 사용하는 여러 곳에 서로 다르게 구현되어 있다?
    - 이게 공통 모듈로 정의를 해놓고 사용하는 의미가 있는지...
    - 설계를 잘못했나...

<br>
<br>
<br>

## 화면 캡처
<img width="530" height="763" alt="image" src="https://github.com/user-attachments/assets/d56b8f79-7ef6-4b89-bc35-9143ecb6a7e7" />
