### PR TITLE
[feat] 회원가입 페이지 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,10 @@ app.get('/login', (req, res) => {
     res.sendFile(path.join(import.meta.dirname, 'public', 'login', 'login.html'));
 });
 
+app.get('/register', (req, res) => {
+    res.sendFile(path.join(import.meta.dirname, 'public', 'register', 'register.html'));
+});
+
 app.get('/write', (req, res) => {
     res.sendFile(path.join(import.meta.dirname, 'public', 'post-write', 'post-write.html'));
 });

--- a/src/public/api/auth.js
+++ b/src/public/api/auth.js
@@ -1,7 +1,7 @@
 import { request, METHOD } from './request.js';
 
-export const requestLogin = (email, password) => {
-    return request({ method: METHOD.POST, url: '/auth', body: { email, password } });
+export const requestLogin = (requestBody = { email: '', password: '' }) => {
+    return request({ method: METHOD.POST, url: '/auth', body: requestBody });
 };
 
 export const requestLogout = () => {

--- a/src/public/api/members.js
+++ b/src/public/api/members.js
@@ -1,0 +1,13 @@
+import { request, METHOD } from './request.js';
+
+export const requestEmailDuplicationCheck = (email) => {
+    return request({ method: METHOD.POST, url: '/members/availability/email', body: { email } });
+};
+
+export const requestNicknameDuplicationCheck = (nickname) => {
+    return request({ method: METHOD.POST, url: '/members/availability/nickname', body: { nickname } });
+};
+
+export const requestRegister = (requestBody = {}) => {
+    return request({ method: METHOD.POST, url: '/members', body: requestBody });
+};

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -1,3 +1,7 @@
+import { requestLogin } from '../../../api/auth.js';
+import { requestRegister } from '../../../api/members.js';
+
+/* validation */
 /**
  * form 노드를 매개변수로 받아 form 내 필수 입력 값이 모두 입력됐는지 확인합니다
  */
@@ -81,4 +85,57 @@ export const fieldValidationRules = {
     password: validatePasswordPattern,
     confirmedPassword: validateConfirmedPasswordPattern,
     nickname: valdiateNicknamePattern,
+};
+
+/* form HTML과 상호작용 */
+const formSubmitMap = {
+    login: {
+        request: requestLogin,
+        redirectionPath: '/index',
+    },
+    register: {
+        request: requestRegister,
+        redirectionPath: '/login',
+    },
+};
+
+export const validateField = (name, target) => {
+    const value = target.value;
+    const helper = target.nextElementSibling;
+
+    const result = fieldValidationRules[name](value);
+
+    target.dataset.validated = result.isValidated;
+    helper.textContent = result.message;
+
+    return result.isValidated;
+};
+
+export const formSubmitBtnClickHandler = async (pageName) => {
+    const form = document.querySelector('.form');
+
+    if (!validateRequiredInput(form)) {
+        return;
+    }
+
+    // 유효성 검사 통과 못하면 return
+    const inputElements = document.querySelectorAll('[data-validated]');
+    for (const e of inputElements) {
+        if (e.dataset.validated !== 'true') return;
+    }
+
+    const requestBody = {};
+    for (const e of inputElements) {
+        requestBody[e.dataset.fieldname] = e.value;
+    }
+
+    const res = await formSubmitMap[pageName].request(requestBody);
+
+    if (!res.success) {
+        inputElements[0].nextElementSibling.textContent = res.data;
+        // password.nextElementSibling.textContent = '아이디 또는 비밀번호를 확인해주세요';
+        return;
+    }
+
+    location.href = formSubmitMap[pageName].redirectionPath;
 };

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -34,11 +34,32 @@ const validatePasswordPattern = (password) => {
     };
 };
 
+const validateConfirmedPasswordPattern = (password) => {
+    const isValidated = document.querySelector('#form-password-input').value === password;
+    return {
+        isValidated,
+        message: isValidated ? '' : password.length === 0 ? '비밀번호를 한 번 더 입력해주세요' : '비밀번호가 다릅니다',
+    };
+};
+
+const valdiateNicknamePattern = (nickname) => {
+    return {
+        isValidated: !nickname.includes(' ') && nickname.length < 11,
+        message: nickname.includes(' ')
+            ? '띄어쓰기를 없애주세요'
+            : nickname.length > 10
+              ? '닉네임은 최대 10자까지 작성 가능합니다'
+              : nickname.length === 0
+                ? '닉네임을 입력해주세요'
+                : '',
+    };
+};
+
 const validatePostTitlePattern = (title) => {
     return {
         isValidated: title.length > 0 && title.length < 27,
         message:
-            title.length == 0
+            title.length === 0
                 ? '제목을 입력해주세요'
                 : title.length > 26
                   ? '제목은 최대 26글자까지 입력할 수 있습니다'
@@ -49,7 +70,7 @@ const validatePostTitlePattern = (title) => {
 const validatePostContentPattern = (content) => {
     return {
         isValidated: content.length > 0,
-        message: content.length == 0 ? '내용을 입력해주세요' : '',
+        message: content.length === 0 ? '내용을 입력해주세요' : '',
     };
 };
 
@@ -58,4 +79,6 @@ export const fieldValidationRules = {
     content: validatePostContentPattern,
     email: validateEmailPattern,
     password: validatePasswordPattern,
+    confirmedPassword: validateConfirmedPasswordPattern,
+    nickname: valdiateNicknamePattern,
 };

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -132,12 +132,14 @@ export const formSubmitBtnClickHandler = async (pageName) => {
 
     // 유효성 검사 통과 못하면 return
     const inputElementsWithValidated = document.querySelectorAll('[data-validated]');
+
     for (const e of inputElementsWithValidated) {
         if (e.dataset.validated !== 'true') return;
     }
 
     const inputElements = document.querySelectorAll('.form-input');
     const requestBody = {};
+
     for (const e of inputElements) {
         requestBody[e.dataset.fieldname] = e.value;
     }

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -44,7 +44,7 @@ const validateConfirmedPasswordPattern = (password) => {
 
 const valdiateNicknamePattern = (nickname) => {
     return {
-        isValidated: !nickname.includes(' ') && nickname.length < 11,
+        isValidated: !nickname.includes(' ') && nickname.length < 11 && nickname.length > 0,
         message: nickname.includes(' ')
             ? '띄어쓰기를 없애주세요'
             : nickname.length > 10

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -103,7 +103,19 @@ export const validateField = (name, target) => {
     const value = target.value;
     const helper = target.nextElementSibling;
 
+    const previousIsChanged = target.dataset.ischanged === 'true';
+
+    // 수정 여부 판단
+    if (!previousIsChanged) {
+        target.dataset.ischanged = true;
+    }
+
+    const previousValidated = target.dataset.validated === 'true';
     const result = fieldValidationRules[name](value);
+
+    if (previousValidated == result.isValidated) {
+        return previousValidated;
+    }
 
     target.dataset.validated = result.isValidated;
     helper.textContent = result.message;
@@ -119,11 +131,12 @@ export const formSubmitBtnClickHandler = async (pageName) => {
     }
 
     // 유효성 검사 통과 못하면 return
-    const inputElements = document.querySelectorAll('[data-validated]');
-    for (const e of inputElements) {
+    const inputElementsWithValidated = document.querySelectorAll('[data-validated]');
+    for (const e of inputElementsWithValidated) {
         if (e.dataset.validated !== 'true') return;
     }
 
+    const inputElements = document.querySelectorAll('.form-input');
     const requestBody = {};
     for (const e of inputElements) {
         requestBody[e.dataset.fieldname] = e.value;
@@ -133,9 +146,22 @@ export const formSubmitBtnClickHandler = async (pageName) => {
 
     if (!res.success) {
         inputElements[0].nextElementSibling.textContent = res.data;
-        // password.nextElementSibling.textContent = '아이디 또는 비밀번호를 확인해주세요';
         return;
     }
 
     location.href = formSubmitMap[pageName].redirectionPath;
+};
+
+export const ChangeFormSubmitBtnStatus = () => {
+    const validatedInputElements = document.querySelectorAll('[data-validated]');
+    const formSubmitBtn = document.querySelector('.form-submit-btn');
+
+    for (const e of validatedInputElements) {
+        if (e.dataset.validated !== 'true') {
+            formSubmitBtn.classList.add('inactivated');
+            return;
+        }
+    }
+
+    formSubmitBtn.classList.remove('inactivated');
 };

--- a/src/public/component/common/header/header.js
+++ b/src/public/component/common/header/header.js
@@ -3,7 +3,7 @@ import { requestLogout } from '../../../api/auth.js';
 const generateHeaderHtml = (isLogin = false, existsBackward = false) => {
     return `
         <div class="header-container">
-        <div class="backward ${isLogin && existsBackward ? '' : 'conceal'}">
+        <div class="backward ${existsBackward ? '' : 'conceal'}">
             <div class="backward-image">◀️</div>
         </div>
         <div class="title">
@@ -46,7 +46,7 @@ const backwardImageClickHandler = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
-    const backwardList = ['/read', '/write', '/update'];
+    const backwardList = ['/read', '/write', '/update', '/register'];
     const isLogin = document.cookie.includes('isLogin=true');
     const existsBackward = backwardList.some((url) => window.location.pathname.startsWith(url));
 

--- a/src/public/component/post/post.js
+++ b/src/public/component/post/post.js
@@ -1,23 +1,24 @@
 import { formatCount, formatDate } from '../../utils/format-helper.js';
 import { generateWriterInfoHtml } from '../common/member/member.js';
 import { getCookie } from '../../utils/cookie-helper.js';
-import { validateRequiredInput, fieldValidationRules } from '../common/form/form.js';
+import { validateRequiredInput, ChangeFormSubmitBtnStatus, validateField } from '../common/form/form.js';
 import { requestWritePost, requestUpdatePost } from '../../api/posts.js';
+import { debouncedRequest } from '../../utils/debounce-helper.js';
 
 export const paintPostForm = (post = {}) => {
     document.querySelector('section').insertAdjacentHTML('beforeend', generatePostFormHtml(post));
 
-    const formTitleInput = document.querySelector('#form-title-input');
-    const formContentInput = document.querySelector('#form-content-input');
     const formSubmitBtn = document.querySelector('.form-submit-btn');
 
-    formTitleInput.addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('title', target);
-    });
-
-    formContentInput.addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('content', target);
-    });
+    document.querySelectorAll('.form-input').forEach((e) =>
+        e.addEventListener(
+            'input',
+            debouncedRequest(function ({ target }) {
+                validateField(target.dataset.fieldname, target);
+                ChangeFormSubmitBtnStatus();
+            }, 400)
+        )
+    );
 
     formSubmitBtn.addEventListener('click', () => {
         formSubmitBtnClickHandler(post?.id);
@@ -44,6 +45,7 @@ const generatePostFormHtml = (post) => {
                     placeholder="제목을 입력해주세요. (최대 26글자)"
                     data-validated="${post?.title ? 'true' : 'false'}"
                     data-ischanged="false"
+                    data-fieldname="title"
                     value="${post?.title ?? ''}"
                 />
                 <div class="form-helper-text form-helper-title">${post?.title ? '' : '제목을 작성해주세요'}</div>
@@ -57,6 +59,7 @@ const generatePostFormHtml = (post) => {
                     placeholder="내용을 입력해주세요."
                     data-validated="${post?.content ? 'true' : 'false'}"
                     data-ischanged="false"
+                    data-fieldname="content"
                     rows="25"
                 >${post?.content ?? ''}</textarea>
                 <div class="form-helper-text form-helper-content">${post?.title ? '' : '내용을 작성해주세요'}</div>
@@ -113,71 +116,31 @@ const generatePostReadContainerHtml = (post) => {
         </div>`;
 };
 
-/* Event */
-const ChangeFormSubmitBtnStatus = () => {
-    const formTitleInput = document.querySelector('#form-title-input');
-    const formContentInput = document.querySelector('#form-content-input');
-    const formSubmitBtn = document.querySelector('.form-submit-btn');
-
-    if (formTitleInput.dataset.validated === 'true' && formContentInput.dataset.validated === 'true') {
-        formSubmitBtn.classList.remove('inactivated');
-    } else {
-        formSubmitBtn.classList.add('inactivated');
-    }
-};
-
-const formInputKeyUpHandler = (name, target) => {
-    const value = target.value;
-    const helper = target.nextElementSibling;
-
-    const previousIsChanged = target.dataset.ischanged === 'true';
-
-    // 수정 여부 판단
-    if (!previousIsChanged) {
-        target.dataset.ischanged = true;
-    }
-
-    const previousValidated = target.dataset.validated === 'true';
-    const result = fieldValidationRules[name](value);
-
-    if (previousValidated == result.isValidated) {
-        return;
-    }
-
-    target.dataset.validated = result.isValidated;
-    helper.textContent = result.message;
-
-    ChangeFormSubmitBtnStatus();
-};
-
 const formSubmitBtnClickHandler = async (postId) => {
     const form = document.querySelector('.form');
 
     if (!validateRequiredInput(form)) {
         return;
     }
-
-    const title = form.querySelector('#form-title-input');
-    const content = form.querySelector('#form-content-input');
-
-    if (title.dataset.validated !== 'true' || content.dataset.validated !== 'true') {
-        return;
+    // 유효성 검사 통과 못하면 return
+    const inputElementsWithValidated = document.querySelectorAll('[data-validated]');
+    for (const e of inputElementsWithValidated) {
+        if (e.dataset.validated !== 'true') return;
     }
 
+    const inputElements = document.querySelectorAll('.form-input');
     const requestBody = {};
 
-    if (title.dataset.ischanged === 'true') {
-        requestBody.title = title.value;
-    }
-
-    if (content.dataset.ischanged === 'true') {
-        requestBody.content = content.value;
+    for (const e of inputElements) {
+        if (e.dataset.ischanged === 'true') {
+            requestBody[e.dataset.fieldname] = e.value;
+        }
     }
 
     const res = !!postId ? await requestUpdatePost(postId, requestBody) : await requestWritePost(requestBody);
 
     if (!res.success) {
-        content.nextElementSibling.textContent = res.data;
+        inputElements[0].nextElementSibling.textContent = res.data;
         return;
     }
 

--- a/src/public/login/login.html
+++ b/src/public/login/login.html
@@ -45,7 +45,9 @@
                         <button class="btn form-submit-btn" type="button">로그인</button>
                     </div>
                 </form>
-                <div class="register"><button class="btn" type="button">회원가입</button></div>
+                <div class="register">
+                    <button class="btn" type="button"><a href="/register">회원가입</a></button>
+                </div>
             </section>
         </main>
 

--- a/src/public/login/login.html
+++ b/src/public/login/login.html
@@ -26,6 +26,7 @@
                             id="form-email-input"
                             placeholder="이메일을 입력하세요"
                             data-validated="false"
+                            data-fieldname="email"
                         />
                         <div class="form-helper-text form-helper-email"></div>
                     </div>
@@ -38,6 +39,7 @@
                             id="form-password-input"
                             placeholder="비밀번호를 입력하세요"
                             data-validated="false"
+                            data-fieldname="password"
                         />
                         <div class="form-helper-text form-helper-password"></div>
                     </div>

--- a/src/public/login/login.js
+++ b/src/public/login/login.js
@@ -1,48 +1,18 @@
-import { validateRequiredInput, fieldValidationRules } from '../component/common/form/form.js';
-import { requestLogin } from '../api/auth.js';
-
-const formInputKeyUpHandler = (name, target) => {
-    const value = target.value;
-    const helper = target.nextElementSibling;
-
-    const result = fieldValidationRules[name](value);
-
-    target.dataset.validated = result.isValidated;
-    helper.textContent = result.message;
-};
-
-const formSubmitBtnClickHandler = async () => {
-    const form = document.querySelector('.form');
-
-    if (!validateRequiredInput(form)) {
-        return;
-    }
-
-    const email = form.querySelector('#form-email-input');
-    const password = form.querySelector('#form-password-input');
-
-    if (email.dataset.validated !== 'true' || password.dataset.validated !== 'true') {
-        return;
-    }
-
-    const res = await requestLogin(email.value, password.value);
-
-    if (!res.success) {
-        password.nextElementSibling.textContent = '아이디 또는 비밀번호를 확인해주세요';
-        return;
-    }
-
-    location.href = '/index';
-};
+import { validateField, formSubmitBtnClickHandler } from '../component/common/form/form.js';
+import { debouncedRequest } from '../utils/debounce-helper.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-    document.querySelector('#form-email-input').addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('email', target);
+    document.querySelectorAll('.form-input').forEach((e) => {
+        e.addEventListener(
+            'input',
+            debouncedRequest(function ({ target }) {
+                const fieldName = target.dataset.fieldname;
+                validateField(fieldName, target);
+            }, 400)
+        );
     });
 
-    document.querySelector('#form-password-input').addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('password', target);
-    });
+    debouncedRequest();
 
-    document.querySelector('.form-submit-btn').addEventListener('click', formSubmitBtnClickHandler);
+    document.querySelector('.form-submit-btn').addEventListener('click', () => formSubmitBtnClickHandler('login'));
 });

--- a/src/public/post-update/post-update.js
+++ b/src/public/post-update/post-update.js
@@ -1,5 +1,5 @@
-import { requestReadPost, requestUpdatePost } from '../api/posts.js';
 import { paintPostForm } from '../component/post/post.js';
+import { requestReadPost } from '../api/posts.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     const postId = Number(window.location.pathname.split('/').at(2));

--- a/src/public/register/register.css
+++ b/src/public/register/register.css
@@ -1,0 +1,4 @@
+.login {
+    display: flex;
+    justify-content: center;
+}

--- a/src/public/register/register.html
+++ b/src/public/register/register.html
@@ -90,7 +90,7 @@
                         <div class="form-helper-text form-helper-nickname"></div>
                     </div>
                     <div>
-                        <button class="btn form-submit-btn inactivated" type="button" disabled>회원가입</button>
+                        <button class="btn form-submit-btn inactivated" type="button">회원가입</button>
                     </div>
                 </form>
                 <div class="login">

--- a/src/public/register/register.html
+++ b/src/public/register/register.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="ko">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>회원가입</title>
+
+        <link rel="stylesheet" href="../style.css" />
+        <link rel="stylesheet" href="../component/common/header/header.css" />
+        <link rel="stylesheet" href="../component/common/form/form.css" />
+        <link rel="stylesheet" href="./register.css" />
+    </head>
+    <body>
+        <header></header>
+
+        <main>
+            <section>
+                <div class="title"><span>회원가입</span></div>
+                <form class="form">
+                    <div>
+                        <label for="form-email-input" class="form-label">프로필 사진</label>
+                        <input name="이미지" type="file" class="" id="form-file-input" data-ischanged="false" />
+                        <div class="form-helper-text form-helper-email"></div>
+                    </div>
+                    <div>
+                        <label for="form-email-input" class="form-label">이메일</label>
+                        <input
+                            name="이메일"
+                            type="email"
+                            class="form-input required"
+                            id="form-email-input"
+                            placeholder="이메일을 입력하세요"
+                            data-validated="false"
+                            data-ischanged="false"
+                            data-fieldname="email"
+                        />
+                        <div class="form-helper-text form-helper-email"></div>
+                    </div>
+                    <div>
+                        <label for="form-password-input" class="form-label">비밀번호</label>
+                        <input
+                            name="비밀번호"
+                            type="password"
+                            class="form-input required"
+                            id="form-password-input"
+                            placeholder="비밀번호를 입력하세요"
+                            data-validated="false"
+                            data-ischanged="false"
+                            data-fieldname="password"
+                        />
+                        <div class="form-helper-text form-helper-password"></div>
+                    </div>
+                    <div>
+                        <label for="form-confirmed-password-input" class="form-label">비밀번호 확인</label>
+                        <input
+                            name="비밀번호 확인"
+                            type="password"
+                            class="form-input required"
+                            id="form-confirmed-password-input"
+                            placeholder="비밀번호를 한 번 더 입력하세요"
+                            data-validated="false"
+                            data-ischanged="false"
+                            data-fieldname="confirmedPassword"
+                        />
+                        <div class="form-helper-text form-helper-confirmed-password"></div>
+                    </div>
+                    <div>
+                        <label for="form-nickname-input" class="form-label">닉네임</label>
+                        <input
+                            name="닉네임"
+                            type="text"
+                            class="form-input required"
+                            id="form-nickname-input"
+                            placeholder="닉네임을 입력하세요"
+                            data-validated="false"
+                            data-ischanged="false"
+                            data-fieldname="nickname"
+                        />
+                        <div class="form-helper-text form-helper-nickname"></div>
+                    </div>
+                    <div>
+                        <button class="btn form-submit-btn" type="button">회원가입</button>
+                    </div>
+                </form>
+                <div class="login">
+                    <button class="btn" type="button"><a href="/login">로그인하러 가기</a></button>
+                </div>
+            </section>
+        </main>
+
+        <script type="module" src="../component/common/header/header.js"></script>
+        <script type="module" src="./register.js"></script>
+    </body>
+</html>

--- a/src/public/register/register.html
+++ b/src/public/register/register.html
@@ -90,7 +90,7 @@
                         <div class="form-helper-text form-helper-nickname"></div>
                     </div>
                     <div>
-                        <button class="btn form-submit-btn" type="button">회원가입</button>
+                        <button class="btn form-submit-btn inactivated" type="button" disabled>회원가입</button>
                     </div>
                 </form>
                 <div class="login">

--- a/src/public/register/register.html
+++ b/src/public/register/register.html
@@ -19,7 +19,14 @@
                 <form class="form">
                     <div>
                         <label for="form-email-input" class="form-label">프로필 사진</label>
-                        <input name="이미지" type="file" class="" id="form-file-input" data-ischanged="false" />
+                        <input
+                            name="이미지"
+                            type="file"
+                            class=""
+                            id="form-file-input"
+                            data-ischanged="false"
+                            data-unique="false"
+                        />
                         <div class="form-helper-text form-helper-email"></div>
                     </div>
                     <div>
@@ -33,6 +40,7 @@
                             data-validated="false"
                             data-ischanged="false"
                             data-fieldname="email"
+                            data-unique="true"
                         />
                         <div class="form-helper-text form-helper-email"></div>
                     </div>
@@ -47,6 +55,7 @@
                             data-validated="false"
                             data-ischanged="false"
                             data-fieldname="password"
+                            data-unique="false"
                         />
                         <div class="form-helper-text form-helper-password"></div>
                     </div>
@@ -61,6 +70,7 @@
                             data-validated="false"
                             data-ischanged="false"
                             data-fieldname="confirmedPassword"
+                            data-unique="false"
                         />
                         <div class="form-helper-text form-helper-confirmed-password"></div>
                     </div>
@@ -75,6 +85,7 @@
                             data-validated="false"
                             data-ischanged="false"
                             data-fieldname="nickname"
+                            data-unique="true"
                         />
                         <div class="form-helper-text form-helper-nickname"></div>
                     </div>

--- a/src/public/register/register.js
+++ b/src/public/register/register.js
@@ -1,0 +1,61 @@
+import { validateRequiredInput, fieldValidationRules } from '../component/common/form/form.js';
+import { requestRegister } from '../api/members.js';
+
+const formInputKeyUpHandler = (name, target) => {
+    const value = target.value;
+    const helper = target.nextElementSibling;
+
+    const result = fieldValidationRules[name](value);
+
+    target.dataset.validated = result.isValidated;
+    helper.textContent = result.message;
+};
+
+const formSubmitBtnClickHandler = async () => {
+    const form = document.querySelector('.form');
+
+    if (!validateRequiredInput(form)) {
+        return;
+    }
+
+    // 유효성 검사 통과 못하면 return
+    const inputElements = document.querySelectorAll('[data-validated]');
+    for (const e of inputElements) {
+        if (e.dataset.validated !== 'true') return;
+    }
+
+    const requestBody = {};
+    for (const e of inputElements) {
+        requestBody[e.dataset.fieldname] = e.value;
+    }
+
+    const res = await requestRegister(requestBody);
+
+    if (!res.success) {
+        console.log(res);
+        document.querySelector('#form-nickname-input').nextElementSibling.textContent = res.data;
+        return;
+    }
+
+    location.href = '/login';
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelector('#form-email-input').addEventListener('keyup', ({ target }) => {
+        formInputKeyUpHandler('email', target);
+    });
+
+    document.querySelector('#form-password-input').addEventListener('keyup', ({ target }) => {
+        formInputKeyUpHandler('password', target);
+    });
+
+    document.querySelector('#form-confirmed-password-input').addEventListener('keyup', ({ target }) => {
+        formInputKeyUpHandler('confirmedPassword', target);
+    });
+
+    document.querySelector('#form-nickname-input').addEventListener('keyup', ({ target }) => {
+        formInputKeyUpHandler('nickname', target);
+    });
+
+    document.querySelector('.form-submit-btn').addEventListener('click', formSubmitBtnClickHandler);
+});

--- a/src/public/register/register.js
+++ b/src/public/register/register.js
@@ -1,5 +1,6 @@
 import { validateRequiredInput, fieldValidationRules } from '../component/common/form/form.js';
 import { requestEmailDuplicationCheck, requestNicknameDuplicationCheck, requestRegister } from '../api/members.js';
+import { debouncedRequest } from '../utils/debounce-helper.js';
 
 const requestMap = {
     email: requestEmailDuplicationCheck,
@@ -33,17 +34,6 @@ const formSubmitBtnClickHandler = async () => {
 
     location.href = '/login';
 };
-
-function debouncedRequest(fn, delay = 200) {
-    let timer;
-    return function () {
-        const args = arguments;
-        clearTimeout(timer);
-        timer = setTimeout(() => {
-            fn.apply(this, args);
-        }, delay);
-    };
-}
 
 const validateField = (name, target) => {
     const value = target.value;

--- a/src/public/register/register.js
+++ b/src/public/register/register.js
@@ -1,26 +1,10 @@
+import { validateField, formSubmitBtnClickHandler, ChangeFormSubmitBtnStatus } from '../component/common/form/form.js';
 import { requestEmailDuplicationCheck, requestNicknameDuplicationCheck } from '../api/members.js';
-import { validateField, formSubmitBtnClickHandler } from '../component/common/form/form.js';
 import { debouncedRequest } from '../utils/debounce-helper.js';
 
 const requestMap = {
     email: requestEmailDuplicationCheck,
     nickname: requestNicknameDuplicationCheck,
-};
-
-const ChangeFormSubmitBtnStatus = () => {
-    const validatedInputElements = document.querySelectorAll('[data-validated]');
-    const formSubmitBtn = document.querySelector('.form-submit-btn');
-
-    for (const e of validatedInputElements) {
-        if (e.dataset.validated !== 'true') {
-            formSubmitBtn.classList.add('inactivated');
-            formSubmitBtn.disabled = true;
-            return;
-        }
-    }
-
-    formSubmitBtn.classList.remove('inactivated');
-    formSubmitBtn.disabled = false;
 };
 
 const inputFormInputHandlerDebounced = (inputElement) => {

--- a/src/public/register/register.js
+++ b/src/public/register/register.js
@@ -1,14 +1,9 @@
 import { validateRequiredInput, fieldValidationRules } from '../component/common/form/form.js';
-import { requestRegister } from '../api/members.js';
+import { requestEmailDuplicationCheck, requestNicknameDuplicationCheck, requestRegister } from '../api/members.js';
 
-const formInputKeyUpHandler = (name, target) => {
-    const value = target.value;
-    const helper = target.nextElementSibling;
-
-    const result = fieldValidationRules[name](value);
-
-    target.dataset.validated = result.isValidated;
-    helper.textContent = result.message;
+const requestMap = {
+    email: requestEmailDuplicationCheck,
+    nickname: requestNicknameDuplicationCheck,
 };
 
 const formSubmitBtnClickHandler = async () => {
@@ -32,30 +27,64 @@ const formSubmitBtnClickHandler = async () => {
     const res = await requestRegister(requestBody);
 
     if (!res.success) {
-        console.log(res);
-        document.querySelector('#form-nickname-input').nextElementSibling.textContent = res.data;
+        inputElements[0].nextElementSibling.textContent = res.data;
         return;
     }
 
     location.href = '/login';
 };
 
+function debouncedRequest(fn, delay = 200) {
+    let timer;
+    return function () {
+        const args = arguments;
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+            fn.apply(this, args);
+        }, delay);
+    };
+}
+
+const formInputKeyUpHandler = (name, target) => {
+    const value = target.value;
+    const helper = target.nextElementSibling;
+
+    const result = fieldValidationRules[name](value);
+
+    target.dataset.validated = result.isValidated;
+    helper.textContent = result.message;
+
+    return result.isValidated;
+};
+
+const inputFormInputHandlerDebounced = (inputElement) => {
+    inputElement.addEventListener(
+        'input',
+        debouncedRequest(async function ({ target }) {
+            const isUnique = target.dataset.unique === 'true';
+            const fieldName = target.dataset.fieldname;
+            const fieldValue = target.value;
+
+            if (!formInputKeyUpHandler(fieldName, target)) {
+                // 유효한 값이 아니라면 중복 체크 요청을 보내지 않음
+                return;
+            }
+
+            if (!isUnique) {
+                // 중복 체크 요청 필요 없음
+                return;
+            }
+
+            const res = await requestMap[fieldName](fieldValue);
+
+            if (!res.success) {
+                target.nextElementSibling.textContent = res.data;
+            }
+        }, 400)
+    );
+};
+
 document.addEventListener('DOMContentLoaded', () => {
-    document.querySelector('#form-email-input').addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('email', target);
-    });
-
-    document.querySelector('#form-password-input').addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('password', target);
-    });
-
-    document.querySelector('#form-confirmed-password-input').addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('confirmedPassword', target);
-    });
-
-    document.querySelector('#form-nickname-input').addEventListener('keyup', ({ target }) => {
-        formInputKeyUpHandler('nickname', target);
-    });
-
+    document.querySelectorAll('.form-input').forEach((e) => inputFormInputHandlerDebounced(e));
     document.querySelector('.form-submit-btn').addEventListener('click', formSubmitBtnClickHandler);
 });

--- a/src/public/register/register.js
+++ b/src/public/register/register.js
@@ -1,50 +1,10 @@
-import { validateRequiredInput, fieldValidationRules } from '../component/common/form/form.js';
-import { requestEmailDuplicationCheck, requestNicknameDuplicationCheck, requestRegister } from '../api/members.js';
+import { requestEmailDuplicationCheck, requestNicknameDuplicationCheck } from '../api/members.js';
+import { validateField, formSubmitBtnClickHandler } from '../component/common/form/form.js';
 import { debouncedRequest } from '../utils/debounce-helper.js';
 
 const requestMap = {
     email: requestEmailDuplicationCheck,
     nickname: requestNicknameDuplicationCheck,
-};
-
-const formSubmitBtnClickHandler = async () => {
-    const form = document.querySelector('.form');
-
-    if (!validateRequiredInput(form)) {
-        return;
-    }
-
-    // 유효성 검사 통과 못하면 return
-    const inputElements = document.querySelectorAll('[data-validated]');
-    for (const e of inputElements) {
-        if (e.dataset.validated !== 'true') return;
-    }
-
-    const requestBody = {};
-    for (const e of inputElements) {
-        requestBody[e.dataset.fieldname] = e.value;
-    }
-
-    const res = await requestRegister(requestBody);
-
-    if (!res.success) {
-        inputElements[0].nextElementSibling.textContent = res.data;
-        return;
-    }
-
-    location.href = '/login';
-};
-
-const validateField = (name, target) => {
-    const value = target.value;
-    const helper = target.nextElementSibling;
-
-    const result = fieldValidationRules[name](value);
-
-    target.dataset.validated = result.isValidated;
-    helper.textContent = result.message;
-
-    return result.isValidated;
 };
 
 const ChangeFormSubmitBtnStatus = () => {
@@ -88,5 +48,5 @@ const inputFormInputHandlerDebounced = (inputElement) => {
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.form-input').forEach((e) => inputFormInputHandlerDebounced(e));
-    document.querySelector('.form-submit-btn').addEventListener('click', formSubmitBtnClickHandler);
+    document.querySelector('.form-submit-btn').addEventListener('click', () => formSubmitBtnClickHandler('register'));
 });

--- a/src/public/register/register.js
+++ b/src/public/register/register.js
@@ -45,7 +45,7 @@ function debouncedRequest(fn, delay = 200) {
     };
 }
 
-const formInputKeyUpHandler = (name, target) => {
+const validateField = (name, target) => {
     const value = target.value;
     const helper = target.nextElementSibling;
 
@@ -57,6 +57,22 @@ const formInputKeyUpHandler = (name, target) => {
     return result.isValidated;
 };
 
+const ChangeFormSubmitBtnStatus = () => {
+    const validatedInputElements = document.querySelectorAll('[data-validated]');
+    const formSubmitBtn = document.querySelector('.form-submit-btn');
+
+    for (const e of validatedInputElements) {
+        if (e.dataset.validated !== 'true') {
+            formSubmitBtn.classList.add('inactivated');
+            formSubmitBtn.disabled = true;
+            return;
+        }
+    }
+
+    formSubmitBtn.classList.remove('inactivated');
+    formSubmitBtn.disabled = false;
+};
+
 const inputFormInputHandlerDebounced = (inputElement) => {
     inputElement.addEventListener(
         'input',
@@ -65,21 +81,17 @@ const inputFormInputHandlerDebounced = (inputElement) => {
             const fieldName = target.dataset.fieldname;
             const fieldValue = target.value;
 
-            if (!formInputKeyUpHandler(fieldName, target)) {
-                // 유효한 값이 아니라면 중복 체크 요청을 보내지 않음
-                return;
+            if (validateField(fieldName, target) && isUnique) {
+                // 유효한 값이면서 중복 체크 요청이 필요한 경우에만 백엔드 서버로 request 요청
+                const res = await requestMap[fieldName](fieldValue);
+
+                if (!res.success) {
+                    target.nextElementSibling.textContent = res.data;
+                    target.dataset.validated = false;
+                }
             }
 
-            if (!isUnique) {
-                // 중복 체크 요청 필요 없음
-                return;
-            }
-
-            const res = await requestMap[fieldName](fieldValue);
-
-            if (!res.success) {
-                target.nextElementSibling.textContent = res.data;
-            }
+            ChangeFormSubmitBtnStatus();
         }, 400)
     );
 };

--- a/src/public/utils/debounce-helper.js
+++ b/src/public/utils/debounce-helper.js
@@ -1,0 +1,11 @@
+// 연속적으로 발생한 이벤트 중 마지막으로 발생한 이벤트만 처리
+export function debouncedRequest(fn, delay = 200) {
+    let timer;
+    return function () {
+        const args = arguments;
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+            fn.apply(this, args);
+        }, delay);
+    };
+}


### PR DESCRIPTION
## 작업 내용

- 회원가입, 이메일/닉네임 중복 체크 요청 보내는 함수 작성
    - input 태그에 `data-unique` 속성이 true라면 `data-fieldname`을 참고해 중복 체크 요청 날림
- 비밀번호 확인과 닉네임의 유효 값 검증 함수 작성
- debounce 적용해 input 태그 입력에 따른 검증/API 요청 실행 빈도 낮춤
    - 기존 로그인 페이지, 게시글 작성/수정 페이지에도 debounce 적용하도록 리팩토링
- 기존 게시글 작성/수정 페이지와 로그인 페이지에서 사용하던 form 관련 공통 로직 `component/form/form.js`로 이동
    - 두 곳에서 사용하는 로직과 회원가입, 회원정보 수정에서 사용하는 로직이 동일하기 때문
    - 공통적으로 사용하기 위해 각 input에 `data-fieldname` 속성 추가

## 고민 내용

### 사용자가 입력할 때마다 이메일, 닉네임 중복 요청 날리는 건 너무 비싸다
- 그 전까지 입력 값 검증할 때는 자바스크립트 함수를 실행하는 거니 그냥 넘어갔음
- 그러나 중복 확인 요청은 외부로 API를 날리고, 그로 인해 서버에서 쿼리문이 실행되는 비싼 작업
- 이걸 매 입력마다 요청 날리긴 부담스러움
- 그래서 디바운스 적용함
    - 겸사겸사 입력 값 검증하는 것도 디바운스 적용해 리팩토링

## 화면 캡처
- 회원가입 버튼 비활성화
    <img width="527" height="760" alt="image" src="https://github.com/user-attachments/assets/b8b9bbce-0f8d-4597-8622-317639dabf7c" />

- 회원가입 버튼 활성화
    <img width="527" height="759" alt="image" src="https://github.com/user-attachments/assets/3203eb0c-370c-49a7-a347-db6ec4c3e533" />
