### PR TITLE
[feat] 댓글 생성과 수정 기능 구현 (#16)

### DIFF
--- a/src/public/api/comments.js
+++ b/src/public/api/comments.js
@@ -8,6 +8,16 @@ export const requestComments = (postId, params = {}) => {
     return request({ url: `/posts/${postId}/comments`, params: createQueryString(params) });
 };
 
+export const requestWriteComment = (requestBody = {}) => {
+    const postId = Number(window.location.pathname.split('/').at(2));
+    return request({ method: METHOD.POST, url: `/posts/${postId}/comments`, body: requestBody });
+};
+
+export const requestUpdateComment = (commentId, requestBody = {}) => {
+    const postId = Number(window.location.pathname.split('/').at(2));
+    return request({ method: METHOD.PATCH, url: `/posts/${postId}/comments/${commentId}`, body: requestBody });
+};
+
 export const requestDeleteComment = (commentId) => {
     const postId = Number(window.location.pathname.split('/').at(2));
     return request({ method: METHOD.DELETE, url: `/posts/${postId}/comments/${commentId}` });

--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -51,7 +51,7 @@ const generateCommentUpdateFormHtml = (comment) => {
                 <div class="form-helper-text form-helper-content"></div>
             </div>
             <div>
-                <button class="btn form-submit-btn form-update-submit-btn ${comment?.id ? '' : 'inactivated'}" type="button">${!!comment?.id ? '수정' : '등록'}</button>
+                <button class="btn form-submit-btn form-update-submit-btn ${comment?.id ? '' : 'inactivated'}" type="button">수정</button>
             </div>
         </form>`;
 };
@@ -173,32 +173,33 @@ export const paintCommentsContainer = (comments, loginMemberId) => {
         .querySelector('.comments-container')
         .insertAdjacentHTML('beforeend', generateCommentsContainerHtml(comments, loginMemberId));
 
-    document.querySelectorAll('.comment-update-btn').forEach((btn) => {
-        btn.addEventListener('click', () => {
-            const commentContainerElement = btn.closest('.comment-container');
-            const commentContentElement = commentContainerElement.querySelector('.comment-content');
-            const content = commentContentElement.textContent;
-            const id = btn.dataset.id;
+    document.querySelector('.comments-container').addEventListener('click', ({ target }) => {
+        if (!target.classList.contains('comment-update-btn')) return;
 
-            commentContentElement.textContent = '';
-            commentContentElement.insertAdjacentHTML('beforeend', generateCommentUpdateFormHtml({ id, content }));
+        const btn = target;
+        const commentContainerElement = btn.closest('.comment-container');
+        const commentContentElement = commentContainerElement.querySelector('.comment-content');
+        const content = commentContentElement.textContent;
+        const id = btn.dataset.id;
 
-            const formElement = commentContainerElement.querySelector('.form');
+        commentContentElement.textContent = '';
+        commentContentElement.insertAdjacentHTML('beforeend', generateCommentUpdateFormHtml({ id, content }));
 
-            commentContainerElement.querySelectorAll('.form-input').forEach((e) =>
-                e.addEventListener(
-                    'input',
-                    debouncedRequest(function ({ target }) {
-                        validateField(target.dataset.keyname, target);
-                        ChangeFormSubmitBtnStatus2(formElement);
-                    }, 400)
-                )
-            );
+        const formElement = commentContainerElement.querySelector('.form');
 
-            document.querySelector('.form-update-submit-btn').addEventListener('click', () => {
-                updateFormSubmitBtnClickHandler(formElement, id, () => {
-                    commentContentElement.textContent = formElement.querySelector('#form-content-input').value;
-                });
+        commentContainerElement.querySelectorAll('.form-input').forEach((e) =>
+            e.addEventListener(
+                'input',
+                debouncedRequest(function ({ target }) {
+                    validateField(target.dataset.keyname, target);
+                    ChangeFormSubmitBtnStatus2(formElement);
+                }, 400)
+            )
+        );
+
+        document.querySelector('.form-update-submit-btn').addEventListener('click', () => {
+            updateFormSubmitBtnClickHandler(formElement, id, () => {
+                commentContentElement.textContent = formElement.querySelector('#form-content-input').value;
             });
         });
     });

--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -1,10 +1,38 @@
-import { validateRequiredInput, ChangeFormSubmitBtnStatus, validateField } from '../common/form/form.js';
+import {
+    validateRequiredInput,
+    ChangeFormSubmitBtnStatus,
+    ChangeFormSubmitBtnStatus2,
+    validateField,
+} from '../common/form/form.js';
 import { generateWriterInfoHtml } from '../common/member/member.js';
 import { debouncedRequest } from '../../utils/debounce-helper.js';
 import { formatDate } from '../../utils/format-helper.js';
 import { requestUpdateComment, requestWriteComment } from '../../api/comments.js';
 
-const generateCommentFormHtml = (comment) => {
+const generateCommentWriteFormHtml = () => {
+    return `
+        <form class="form">
+            <div>
+                <textarea
+                    name="댓글"
+                    class="form-input required"
+                    id="form-content-input"
+                    placeholder="댓글을 입력해주세요."
+                    data-validated="false"
+                    data-ischanged="false"
+                    data-fieldname="content"
+                    data-keyname="commentContent"
+                    rows="10"
+                ></textarea>
+                <div class="form-helper-text form-helper-content"></div>
+            </div>
+            <div>
+                <button class="btn form-submit-btn inactivated" type="button">등록</button>
+            </div>
+        </form>`;
+};
+
+const generateCommentUpdateFormHtml = (comment) => {
     return `
         <form class="form">
             <div>
@@ -17,12 +45,13 @@ const generateCommentFormHtml = (comment) => {
                     data-ischanged="false"
                     data-fieldname="content"
                     data-keyname="commentContent"
+                    data-id="${comment?.id ?? ''}"
                     rows="10"
                 >${comment?.content ?? ''}</textarea>
                 <div class="form-helper-text form-helper-content"></div>
             </div>
             <div>
-                <button class="btn form-submit-btn ${comment?.id ? '' : 'inactivated'}" type="button">완료</button>
+                <button class="btn form-submit-btn form-update-submit-btn ${comment?.id ? '' : 'inactivated'}" type="button">${!!comment?.id ? '수정' : '등록'}</button>
             </div>
         </form>`;
 };
@@ -31,7 +60,7 @@ const generateCommentContainerHtml = (comment, loginMemberId) => {
     const updateDeleteBtnHtml = () => {
         return `
             <div>
-                <button class="btn small-btn" data-id=${comment.id}>수정</button>
+                <button class="btn small-btn comment-update-btn" data-id=${comment.id}>수정</button>
                 <button class="btn small-btn delete-btn" data-domain="comment" data-id="${comment.id}">삭제</button>
             </div>`;
     };
@@ -90,8 +119,39 @@ export const formSubmitBtnClickHandler = async (commentId) => {
     document.querySelector('#form-content-input').value = '';
 };
 
+const updateFormSubmitBtnClickHandler = async (form, commentId, afterSubmit) => {
+    if (!validateRequiredInput(form)) {
+        return;
+    }
+
+    // 유효성 검사 통과 못하면 return
+    const inputElementsWithValidated = form.querySelectorAll('[data-validated]');
+
+    for (const e of inputElementsWithValidated) {
+        if (e.dataset.validated !== 'true') return;
+    }
+
+    const inputElements = form.querySelectorAll('.form-input');
+    const requestBody = {};
+
+    for (const e of inputElements) {
+        requestBody[e.dataset.fieldname] = e.value;
+    }
+
+    const res = await requestUpdateComment(commentId, requestBody);
+
+    if (!res.success) {
+        inputElements[0].nextElementSibling.textContent = res.data;
+        return;
+    }
+
+    afterSubmit();
+};
+
 export const paintCommentFormContainer = (comment = {}) => {
-    document.querySelector('.comment-form-container').insertAdjacentHTML('beforeend', generateCommentFormHtml(comment));
+    document
+        .querySelector('.comment-form-container')
+        .insertAdjacentHTML('beforeend', generateCommentWriteFormHtml(comment));
 
     document.querySelectorAll('.form-input').forEach((e) =>
         e.addEventListener(
@@ -112,4 +172,34 @@ export const paintCommentsContainer = (comments, loginMemberId) => {
     document
         .querySelector('.comments-container')
         .insertAdjacentHTML('beforeend', generateCommentsContainerHtml(comments, loginMemberId));
+
+    document.querySelectorAll('.comment-update-btn').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const commentContainerElement = btn.closest('.comment-container');
+            const commentContentElement = commentContainerElement.querySelector('.comment-content');
+            const content = commentContentElement.textContent;
+            const id = btn.dataset.id;
+
+            commentContentElement.textContent = '';
+            commentContentElement.insertAdjacentHTML('beforeend', generateCommentUpdateFormHtml({ id, content }));
+
+            const formElement = commentContainerElement.querySelector('.form');
+
+            commentContainerElement.querySelectorAll('.form-input').forEach((e) =>
+                e.addEventListener(
+                    'input',
+                    debouncedRequest(function ({ target }) {
+                        validateField(target.dataset.keyname, target);
+                        ChangeFormSubmitBtnStatus2(formElement);
+                    }, 400)
+                )
+            );
+
+            document.querySelector('.form-update-submit-btn').addEventListener('click', () => {
+                updateFormSubmitBtnClickHandler(formElement, id, () => {
+                    commentContentElement.textContent = formElement.querySelector('#form-content-input').value;
+                });
+            });
+        });
+    });
 };

--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -1,5 +1,31 @@
-import { formatDate } from '../../utils/format-helper.js';
+import { validateRequiredInput, ChangeFormSubmitBtnStatus, validateField } from '../common/form/form.js';
 import { generateWriterInfoHtml } from '../common/member/member.js';
+import { debouncedRequest } from '../../utils/debounce-helper.js';
+import { formatDate } from '../../utils/format-helper.js';
+import { requestUpdateComment, requestWriteComment } from '../../api/comments.js';
+
+const generateCommentFormHtml = (comment) => {
+    return `
+        <form class="form">
+            <div>
+                <textarea
+                    name="댓글"
+                    class="form-input required"
+                    id="form-content-input"
+                    placeholder="댓글을 입력해주세요."
+                    data-validated="${comment?.content ? 'true' : 'false'}"
+                    data-ischanged="false"
+                    data-fieldname="content"
+                    data-keyname="commentContent"
+                    rows="10"
+                >${comment?.content ?? ''}</textarea>
+                <div class="form-helper-text form-helper-content"></div>
+            </div>
+            <div>
+                <button class="btn form-submit-btn ${comment?.id ? '' : 'inactivated'}" type="button">완료</button>
+            </div>
+        </form>`;
+};
 
 const generateCommentContainerHtml = (comment, loginMemberId) => {
     const updateDeleteBtnHtml = () => {
@@ -25,6 +51,61 @@ const generateCommentContainerHtml = (comment, loginMemberId) => {
 
 const generateCommentsContainerHtml = (comments, loginMemberId) => {
     return comments.map((comment) => generateCommentContainerHtml(comment, loginMemberId)).join('');
+};
+
+export const formSubmitBtnClickHandler = async (commentId) => {
+    const form = document.querySelector('.form');
+
+    if (!validateRequiredInput(form)) {
+        return;
+    }
+
+    // 유효성 검사 통과 못하면 return
+    const inputElementsWithValidated = document.querySelectorAll('[data-validated]');
+
+    for (const e of inputElementsWithValidated) {
+        if (e.dataset.validated !== 'true') return;
+    }
+
+    const inputElements = document.querySelectorAll('.form-input');
+    const requestBody = {};
+
+    for (const e of inputElements) {
+        requestBody[e.dataset.fieldname] = e.value;
+    }
+
+    const res = !!commentId
+        ? await requestUpdateComment(commentId, requestBody)
+        : await requestWriteComment(requestBody);
+
+    if (!res.success) {
+        inputElements[0].nextElementSibling.textContent = res.data;
+        return;
+    }
+
+    document.querySelector('.post-comment-count').textContent = res.data.commentCount;
+    document
+        .querySelector('.comments-container')
+        .insertAdjacentHTML('afterbegin', generateCommentContainerHtml(res.data.comment, res.data.comment.member.id));
+    document.querySelector('#form-content-input').value = '';
+};
+
+export const paintCommentFormContainer = (comment = {}) => {
+    document.querySelector('.comment-form-container').insertAdjacentHTML('beforeend', generateCommentFormHtml(comment));
+
+    document.querySelectorAll('.form-input').forEach((e) =>
+        e.addEventListener(
+            'input',
+            debouncedRequest(function ({ target }) {
+                validateField(target.dataset.keyname, target);
+                ChangeFormSubmitBtnStatus();
+            }, 400)
+        )
+    );
+
+    document.querySelector('.form-submit-btn').addEventListener('click', () => {
+        formSubmitBtnClickHandler(comment?.id);
+    });
 };
 
 export const paintCommentsContainer = (comments, loginMemberId) => {

--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -8,6 +8,8 @@ import { generateWriterInfoHtml } from '../common/member/member.js';
 import { debouncedRequest } from '../../utils/debounce-helper.js';
 import { formatDate } from '../../utils/format-helper.js';
 import { requestUpdateComment, requestWriteComment } from '../../api/comments.js';
+import { openModal } from '../common/modal/modal.js';
+import { requestDeleteComment } from '../../api/comments.js';
 
 const generateCommentWriteFormHtml = () => {
     return `
@@ -61,7 +63,7 @@ const generateCommentContainerHtml = (comment, loginMemberId) => {
         return `
             <div>
                 <button class="btn small-btn comment-update-btn" data-id=${comment.id}>수정</button>
-                <button class="btn small-btn delete-btn" data-domain="comment" data-id="${comment.id}">삭제</button>
+                <button class="btn small-btn comment-delete-btn" data-domain="comment" data-id="${comment.id}">삭제</button>
             </div>`;
     };
 
@@ -173,6 +175,21 @@ export const paintCommentsContainer = (comments, loginMemberId) => {
         .querySelector('.comments-container')
         .insertAdjacentHTML('beforeend', generateCommentsContainerHtml(comments, loginMemberId));
 
+    // 댓글 삭제 버튼 클릭 이벤트
+    document.querySelector('.comments-container').addEventListener('click', ({ target }) => {
+        if (!target.classList.contains('comment-delete-btn')) return;
+
+        const { domain, id } = target.dataset;
+
+        openModal({
+            mainText: '댓글을 삭제하시겠습니까?',
+            subText: '삭제한 내용은 복구할 수 없습니다',
+            dataset: target.dataset,
+            onConfirm: () => deleteCommentHandler(id),
+        });
+    });
+
+    // 댓글 수정 버튼 클릭 이벤트
     document.querySelector('.comments-container').addEventListener('click', ({ target }) => {
         if (!target.classList.contains('comment-update-btn')) return;
 
@@ -203,4 +220,17 @@ export const paintCommentsContainer = (comments, loginMemberId) => {
             });
         });
     });
+};
+
+const deleteCommentHandler = async (id) => {
+    const res = await requestDeleteComment(id);
+
+    if (!res.success) {
+        alert(res.data);
+        return;
+    }
+
+    const deletedElement = document.querySelector(`[data-commentid="${id}"]`);
+    document.querySelector('.comments-container').removeChild(deletedElement);
+    document.querySelector('.post-comment-count').textContent = res.data.commentCount;
 };

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -80,8 +80,8 @@ const validatePostContentPattern = (content) => {
 
 const validateCommentPattern = (content) => {
     return {
-        isValidated: content.length > 0 && content.length < 501,
-        message: content.length > 500 ? '댓글은 최대 500글자까지 입력할 수 있습니다' : '',
+        isValidated: content.length > 0 && content.length < 10000,
+        message: content.length > 10000 ? '댓글은 최대 10,000글자까지 입력할 수 있습니다' : '',
     };
 };
 

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -78,6 +78,13 @@ const validatePostContentPattern = (content) => {
     };
 };
 
+const validateCommentPattern = (content) => {
+    return {
+        isValidated: content.length > 0 && content.length < 501,
+        message: content.length > 500 ? '댓글은 최대 500글자까지 입력할 수 있습니다' : '',
+    };
+};
+
 export const fieldValidationRules = {
     title: validatePostTitlePattern,
     content: validatePostContentPattern,
@@ -85,6 +92,7 @@ export const fieldValidationRules = {
     password: validatePasswordPattern,
     confirmedPassword: validateConfirmedPasswordPattern,
     nickname: valdiateNicknamePattern,
+    commentContent: validateCommentPattern,
 };
 
 /* form HTML과 상호작용 */

--- a/src/public/component/common/form/form.js
+++ b/src/public/component/common/form/form.js
@@ -175,3 +175,17 @@ export const ChangeFormSubmitBtnStatus = () => {
 
     formSubmitBtn.classList.remove('inactivated');
 };
+
+export const ChangeFormSubmitBtnStatus2 = (form) => {
+    const validatedInputElements = form.querySelectorAll('[data-validated]');
+    const formSubmitBtn = form.querySelector('.form-submit-btn');
+
+    for (const e of validatedInputElements) {
+        if (e.dataset.validated !== 'true') {
+            formSubmitBtn.classList.add('inactivated');
+            return;
+        }
+    }
+
+    formSubmitBtn.classList.remove('inactivated');
+};

--- a/src/public/post-read/post-read.html
+++ b/src/public/post-read/post-read.html
@@ -19,6 +19,7 @@
             <section>
                 <div class="post-container"></div>
                 <div class="custom-hr"></div>
+                <div class="comment-form-container"></div>
                 <div class="comments-container"></div>
             </section>
         </main>

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -1,7 +1,7 @@
 import { requestCancelLike, requestCreateLike } from '../api/post-like.js';
 import { requestReadPost, requestDeletePost } from '../api/posts.js';
 import { requestComments, requestDeleteComment } from '../api/comments.js';
-import { paintCommentsContainer } from '../component/comments/comments.js';
+import { paintCommentFormContainer, paintCommentsContainer } from '../component/comments/comments.js';
 import { paintPostReadContainer } from '../component/post/post.js';
 import { paintHeader } from '../component/common/header/header.js';
 import { openModal } from '../component/common/modal/modal.js';
@@ -74,6 +74,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     /* 댓글 */
+    paintCommentFormContainer();
+
     const commentRes = await requestComments(postId);
 
     if (!commentRes.success) {

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -1,16 +1,11 @@
 import { requestCancelLike, requestCreateLike } from '../api/post-like.js';
 import { requestReadPost, requestDeletePost } from '../api/posts.js';
-import { requestComments, requestDeleteComment } from '../api/comments.js';
+import { requestComments } from '../api/comments.js';
 import { paintCommentFormContainer, paintCommentsContainer } from '../component/comments/comments.js';
 import { paintPostReadContainer } from '../component/post/post.js';
 import { paintHeader } from '../component/common/header/header.js';
 import { openModal } from '../component/common/modal/modal.js';
 import { getAuth } from '../utils/auth-guard.js';
-
-const deleteHandlerMap = {
-    post: (id) => deletePostHandler(id),
-    comment: (id) => deleteCommentHandler(id),
-};
 
 const deletePostHandler = async (id) => {
     const res = await requestDeletePost(id);
@@ -21,19 +16,6 @@ const deletePostHandler = async (id) => {
     }
 
     location.href = '/index';
-};
-
-const deleteCommentHandler = async (id) => {
-    const res = await requestDeleteComment(id);
-
-    if (!res.success) {
-        alert(res.data);
-        return;
-    }
-
-    const deletedElement = document.querySelector(`[data-commentid="${id}"]`);
-    document.querySelector('.comments-container').removeChild(deletedElement);
-    document.querySelector('.post-comment-count').textContent = res.data.commentCount;
 };
 
 const postLikeCountContainerClickHandler = async (target, postId) => {
@@ -85,17 +67,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     paintCommentsContainer(commentRes.data.comments, loginMemberId);
 
-    /* 삭제 모달 */
-    document.querySelectorAll('.delete-btn').forEach((btn) =>
-        btn.addEventListener('click', () => {
-            const { domain, id } = btn.dataset;
+    /* 게시글 삭제 모달 */
+    document.querySelector('.delete-btn').addEventListener('click', ({ target }) => {
+        console.log(target);
+        const { domain, id } = target.dataset;
 
-            openModal({
-                mainText: `${domain === 'post' ? '게시글을' : '댓글을'} 삭제하시겠습니까?`,
-                subText: '삭제한 내용은 복구할 수 없습니다',
-                dataset: btn.dataset,
-                onConfirm: () => deleteHandlerMap[domain](id),
-            });
-        })
-    );
+        openModal({
+            mainText: '게시글을 삭제하시겠습니까?',
+            subText: '삭제한 내용은 복구할 수 없습니다',
+            dataset: target.dataset,
+            onConfirm: () => deletePostHandler(id),
+        });
+    });
 });


### PR DESCRIPTION
## 관련 이슈
#16

<br><br><br>

## 작업 내용

- 백엔드 서버로 댓글 생성과 수정 요청하는 함수 작성
- 댓글 검증 함수 작성
- 댓글 등록 창 UI 구현 및 등록 이벤트 처리
- 댓글 수정 버튼 클릭 시 해당 댓글 자리에서 수정 UI로 변하도록 구현 및 이벤트 처리

<br><br><br>

## 고민 내용

### 댓글 길이 제한
> https://chanho0912.tistory.com/108 . varchar로 넉넉한 값을 설정하면 어떨까 싶었는데, varchar와 text의 장단점을 더 따져볼 필요가 있음.
- Figma 기획서에선 댓글의 데이터베이스 타입을 TEXT로 지정한다고만 작성되어 있음
- TEXT는 최대 65,535바이트까지 저장 가능 (접두사로 인해 실제론 65,533바이트)
- charset 종류별로 한글이 가장 크게 처리되는 경우는 4바이트
- 한글로 꽉 채운 최악의 케이스에도 DB 오류가 발생하지 않으려면
    - `65,535바이트 % 4바이트 = 약 16,383글자`까지 가능
- 그러나 일반적으로 댓글을 1만 자가 넘게 작성하진 않으므로 댓글 최대 길이 제한을 1만 자로 설정함

### 댓글 수정 UI
- Figma 기획서에선 '수정' 버튼 클릭 시 댓글 입력창에 기존 텍스트 내용이 보여지고, '등록' 버튼이 '수정'으로 바뀐다고 서술함
- 그러나 일반적인 댓글 수정 방식이 아니라 낯섦
- 따라서 수정 버튼을 클릭하면 기존 댓글 텍스트 부분이 입력창으로 바뀌어, 해당 댓글을 수정할 수 있도록 변경함

### 동적으로 추가된 댓글의 수정과 삭제 버튼 클릭 이벤트 처리
- 문제점
    - 새로 등록한 댓글엔 기존 댓글 수정/삭제 이벤트 리스너가 적용되지 않음
- 원인
    - 초기 DOM 로딩 시에만 이미 존재하는 버튼에 대해 이벤트 리스너 등록
    - 따라서 동적으로 추가된 댓글엔 당연히 아무런 이벤트 리스너가 등록되어 있지 않음
- 실패한 해결 아이디어
    - 원래 수정/삭제 버튼에 onclick 속성으로 이벤트를 등록할까 했음
    - 그러나 현재 ES 모듈 구조로 작성 중
    - 즉, commentUpdateBtnClickHandler() 와 같은 함수를 정의하더라도 전역(window)에 등록되지 않음
    - 그래서 버튼 태그에 onclick="commentUpdateBtnClickHandler()"를 작성하면 브라우저가 window 전역에서 해당 함수를 찾지만, ES 모듈 내부 함수는 전역에 노출되지 않으므로 `ReferenceError` 발생
- 결론
    - 따라서 각 수정/삭제 버튼의 부모 영역으로 이벤트를 위임함

<br><br><br>

## 화면 캡처
- 신규 댓글 입력
    <img width="610" height="795" alt="image" src="https://github.com/user-attachments/assets/a4e87bbc-ef03-426c-a78d-f704064dca00" />

- 신규 댓글 입력됨
    <img width="603" height="740" alt="image" src="https://github.com/user-attachments/assets/17dd18b8-56ef-4173-844f-c42d0a1a9d7a" />

- 댓글 수정 칸
    <img width="596" height="859" alt="image" src="https://github.com/user-attachments/assets/2dadd0e2-15d5-4472-8152-db1f99377537" />

- 댓글 수정 완료
    <img width="604" height="826" alt="image" src="https://github.com/user-attachments/assets/3e150a67-d164-41df-bff7-689426c5228f" />
