### PR TITLE
[feat] 무한 스크롤링 구현

### DIFF
--- a/src/public/component/comments/comments.js
+++ b/src/public/component/comments/comments.js
@@ -174,7 +174,9 @@ export const paintCommentsContainer = (comments, loginMemberId) => {
     document
         .querySelector('.comments-container')
         .insertAdjacentHTML('beforeend', generateCommentsContainerHtml(comments, loginMemberId));
+};
 
+export const attachCommentEventHandler = () => {
     // 댓글 삭제 버튼 클릭 이벤트
     document.querySelector('.comments-container').addEventListener('click', ({ target }) => {
         if (!target.classList.contains('comment-delete-btn')) return;

--- a/src/public/index/index.js
+++ b/src/public/index/index.js
@@ -31,4 +31,27 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelector('.posts-container').addEventListener('click', ({ target }) => {
         postsContainerClickHandler(target);
     });
+
+    let isNewPostFetching = false;
+
+    window.addEventListener('scroll', async () => {
+        const hitsBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 1;
+
+        if (!hitsBottom || isNewPostFetching) {
+            return;
+        }
+
+        isNewPostFetching = true;
+
+        const lastPostId = Array.from(document.querySelectorAll('[data-postid]')).at(-1).dataset.postid;
+        const res = await requestPosts({ lastPostId });
+
+        if (!res.success) {
+            document.querySelector('.posts-container').textContent = res.data;
+            return;
+        }
+
+        paintPostContainer(res.data.posts);
+        isNewPostFetching = false;
+    });
 });

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -68,15 +68,42 @@ document.addEventListener('DOMContentLoaded', async () => {
     paintCommentsContainer(commentRes.data.comments, loginMemberId);
 
     /* 게시글 삭제 모달 */
-    document.querySelector('.delete-btn').addEventListener('click', ({ target }) => {
-        console.log(target);
-        const { domain, id } = target.dataset;
+    const postDeleteBtnElement = document.querySelector('.delete-btn');
 
-        openModal({
-            mainText: '게시글을 삭제하시겠습니까?',
-            subText: '삭제한 내용은 복구할 수 없습니다',
-            dataset: target.dataset,
-            onConfirm: () => deletePostHandler(id),
+    if (postDeleteBtnElement) {
+        postDeleteBtnElement.addEventListener('click', ({ target }) => {
+            console.log(target);
+            const { domain, id } = target.dataset;
+
+            openModal({
+                mainText: '게시글을 삭제하시겠습니까?',
+                subText: '삭제한 내용은 복구할 수 없습니다',
+                dataset: target.dataset,
+                onConfirm: () => deletePostHandler(id),
+            });
         });
+    }
+
+    let isNewCommentFetching = false;
+
+    window.addEventListener('scroll', async () => {
+        const hitsBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 1;
+
+        if (!hitsBottom || isNewCommentFetching) {
+            return;
+        }
+
+        isNewCommentFetching = true;
+
+        const lastCommentId = Array.from(document.querySelectorAll('[data-commentid]')).at(-1).dataset.commentid;
+        const res = await requestComments(postId, { lastCommentId });
+
+        if (!res.success) {
+            document.querySelector('.comments-container').textContent = res.data;
+            return;
+        }
+
+        paintCommentsContainer(res.data.comments, loginMemberId);
+        isNewCommentFetching = false;
     });
 });

--- a/src/public/post-read/post-read.js
+++ b/src/public/post-read/post-read.js
@@ -1,7 +1,11 @@
 import { requestCancelLike, requestCreateLike } from '../api/post-like.js';
 import { requestReadPost, requestDeletePost } from '../api/posts.js';
 import { requestComments } from '../api/comments.js';
-import { paintCommentFormContainer, paintCommentsContainer } from '../component/comments/comments.js';
+import {
+    attachCommentEventHandler,
+    paintCommentFormContainer,
+    paintCommentsContainer,
+} from '../component/comments/comments.js';
 import { paintPostReadContainer } from '../component/post/post.js';
 import { paintHeader } from '../component/common/header/header.js';
 import { openModal } from '../component/common/modal/modal.js';
@@ -83,6 +87,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
         });
     }
+
+    /* 댓글 이벤트 등록 */
+    attachCommentEventHandler();
 
     let isNewCommentFetching = false;
 


### PR DESCRIPTION
## 작업 내용

- scroll 이벤트 핸들러에서 스크롤이 바닥을 찍었을 때를 감지해 게시글/댓글 추가 요청 및 동적 html 추가하는 코드 작성
- 댓글 html 추가 등록 함수인 paintCommentsContainer() 안에 있던 댓글 수정/삭제 이벤트 등록 코드를 별도 함수로 분리함
    - 스크롤링할 때마다 paintCommentsContainer() 함수를 호출하는데, 그때마다 이벤트가 중복 등록되기 때문임

<br><br><br>

## 고민 내용

### 스크롤 바닥을 치는 이벤트가 2개씩 실행됨
- 스크롤 바닥을 치면 1번만 해당 이벤트가 처리돼야 하는데 2번 실행됨
- 따라서 isFetching 변수를 사용하여 이벤트 처리 중일 때는 true, 아니면 false로 설정
- 만약 이벤트를 처리하려는데 이미 isFetching이 true라면 실행되지 않음

<br><br><br>

## 화면 캡처
- 게시글 무한 스크롤링
    ![게시글무한스크롤링](https://github.com/user-attachments/assets/8cfc41a2-695e-49e1-a9dd-31193299451b)

- 댓글 무한 스크롤링
    ![댓글무한스크롤링](https://github.com/user-attachments/assets/38b953e7-462e-4fa6-979a-191ee4ebec34)
