### PR TITLE
[fix] 절대 URL로 변경

### DIFF
--- a/src/public/utils/constants.js
+++ b/src/public/utils/constants.js
@@ -1,6 +1,6 @@
 export const API_SERVER_URI = window.location.hostname.includes('localhost')
     ? 'http://localhost:8080/api'
-    : '/api.kbt-comi.store/api';
+    : 'https://api.kbt-comi.store/api';
 
 export const DEFAULT_MEMBER_IMAGE = '/assets/default-profile-image.png';
 


### PR DESCRIPTION
## 작업 내용

- /api.kbt-comi.store/api → https://api.kbt-comi.store/api로 변경
    - 수정 전이면 http://www.kbt-comi.store/api.kbt-comi.store/api로 요청하게 됨