### PR TITLE
[feat] workflow 새로 작성

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,11 @@
+# ❗ Deprecated Workflow
+# This CI pipeline is disabled and kept only for historic reference.
+# Do not remove for now, but it will NOT trigger on push or PR.
+
 name: Express CI/CD
 
 on:
-    push:
-        branches:
-            - develop
+    workflow_dispatch:
 
 jobs:
     push:

--- a/.github/workflows/deploy-s3-cloudfront.yml
+++ b/.github/workflows/deploy-s3-cloudfront.yml
@@ -1,0 +1,42 @@
+name: Deploy Frontend with S3 & CloudFront
+
+on:
+    push:
+        branches:
+            - develop
+
+permissions:
+    id-token: write # OIDC 토큰 발급 허용
+    contents: read # actions/checkout용
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout source
+              uses: actions/checkout@v4
+
+            # 1) GitHub OIDC로 AWS 임시 Credential 받기
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+                  role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+                  aws-region: ${{ secrets.AWS_REGION }}
+
+            # 2) S3에 배포
+            - name: Deploy to S3
+              # a) sync : 변경된 파일만 업로드
+              # b) --delete : 삭제된 파일은 S3 버킷에서도 삭제
+              run: |
+                  aws s3 sync ./src/public s3://${{ secrets.AWS_S3_FRONTEND_BUCKET }} \
+                    --delete
+
+            # 3) 기존 캐시 무효화
+            - name: Invalidate CloudFront Cache
+              # a) --paths "*" : MPA 방식으로 모든 페이지 캐시 무효화
+              run: |
+                  aws cloudfront create-invalidation \
+                    --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} \
+                    --paths "/*"


### PR DESCRIPTION
## 작업 내용

- 기존 워크플로 자동 트리거 제거
    - 기존 워크플로는 도커 이미지를 빌드해 레지스트리에 업로드하고, SSM으로 Private Subnet EC2에 접근해 docker compose를 재시작
    - 자동 실행 중지를 위해 `on: push : branches : develop` → `on: workflow_dispatch:`로 변경
        - 이벤트 트리거가 없으므로 자동 실행되진 않지만, 직접 Actions 탭에서 Run Workflow는 가능

- 새로운 워크플로 작성
    - OIDC 방식으로 임시 권한 획득
        - AWS 액세스 키를 장기 보관하는 것보다 보안적
    - `src/public` 폴더의 파일들만 S3 버킷에 싱크(업로드)
        - 정적 서빙하기 때문에 HTML, JavaScript, CSS 파일만 필요하기 때문에 불필요한 파일 제외하도록 함
            - express 파일(src/app.js, package.json, package-lock.json)
            - Docker 관련 파일 (.dockerignore, Dockerfile)
            - 그 외 (.gitignore, .prettierrcc, README.md)